### PR TITLE
fix: handle recursive JSON discovery

### DIFF
--- a/translation_finder/discovery/files.py
+++ b/translation_finder/discovery/files.py
@@ -548,7 +548,7 @@ class JSONDiscovery(BaseDiscovery):
         try:
             with self.finder.open(path, "rb") as handle:
                 return json.loads(_decode_content(handle.read()))
-        except (OSError, ValueError):
+        except (OSError, RecursionError, ValueError):
             return None
 
     def has_template_less_content(self, result: ResultDict) -> bool:
@@ -613,36 +613,63 @@ class JSONDiscovery(BaseDiscovery):
             return "go-i18n-json-v2"
         return None
 
+    @staticmethod
+    def _iter_nested_dicts(data: dict, level: int) -> Generator[tuple[dict, int]]:
+        seen: set[int] = set()
+        stack = [(data, level)]
+
+        while stack:
+            current, current_level = stack.pop()
+            current_id = id(current)
+            if current_id in seen:
+                continue
+            seen.add(current_id)
+            yield current, current_level
+
+            stack.extend(
+                (value, current_level + 1)
+                for value in current.values()
+                if isinstance(value, dict)
+            )
+
+    @staticmethod
+    def _detect_i18next_format(key: str, value: str) -> str | None:
+        if key.endswith(("_one", "_many", "_other")):
+            return "i18nextv4"
+        if key.endswith("_plural") or "{{" in value:
+            return "i18next"
+        return None
+
     def _detect_nested_format(self, data: dict, level: int) -> str | None:
-        all_strings = True
         i18next = False
         i18nextv4 = False
+        all_strings = True
 
-        # Single loop to detect nested formats and i18next patterns
-        for key, value in data.items():
-            # Check for nested formats at level 0
-            if (
-                level == 0
-                and isinstance(value, dict)
-                and (detected := self._detect_first_level_format(value))
-            ):
-                return detected
+        for current, current_level in self._iter_nested_dicts(data, level):
+            # Single loop to detect nested formats and i18next patterns
+            for key, value in current.items():
+                # Check for nested formats at level 0
+                if (
+                    current_level == 0
+                    and isinstance(value, dict)
+                    and (detected := self._detect_first_level_format(value))
+                ):
+                    return detected
 
-            # Check for i18next patterns
-            if not isinstance(key, str):
-                all_strings = False
-                break
-            if not isinstance(value, str):
-                all_strings = False
-                if isinstance(value, dict):
-                    detected = self._detect_nested_format(value, level + 1)
-                    i18next |= detected == "i18next"
-                    i18nextv4 |= detected == "i18nextv4"
-                    # "json" is intentionally ignored here as the format is already nested at this level
-            elif key.endswith(("_one", "_many", "_other")):
-                i18nextv4 = True
-            elif key.endswith("_plural") or "{{" in value:
-                i18next = True
+                # Check for i18next patterns
+                if not isinstance(key, str):
+                    if current is data:
+                        all_strings = False
+                    break
+                if not isinstance(value, str):
+                    if current is data:
+                        all_strings = False
+                    continue
+
+                detected = self._detect_i18next_format(key, value)
+                i18nextv4 |= detected == "i18nextv4"
+                i18next |= detected == "i18next"
+
         if i18nextv4:
             return "i18nextv4"
         if i18next:
@@ -672,7 +699,7 @@ class JSONDiscovery(BaseDiscovery):
         with self.finder.open(path, "r") as handle:
             try:
                 data = json.load(handle)
-            except ValueError as error:
+            except (RecursionError, ValueError) as error:
                 warnings.warn(f"Could not parse JSON: {error}", stacklevel=0)
                 return
             if isinstance(data, list) and len(data) > 0 and "id" in data[0]:

--- a/translation_finder/test_api.py
+++ b/translation_finder/test_api.py
@@ -4,6 +4,7 @@
 """High level API tests."""
 
 import pathlib
+import tempfile
 from io import StringIO
 
 from .api import cli, discover
@@ -24,6 +25,26 @@ class APITest(DiscoveryTestCase):
                 mock=([(PurePath(path), PurePath(path), path) for path in paths], []),
             ),
             [{"filemask": "locales/*/messages.po", "file_format": "po"}],
+        )
+
+    def test_discover_deeply_nested_json(self) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            root = pathlib.Path(tmpdir)
+            content = '{"a":' * 2000 + "1" + "}" * 2000
+            (root / "en.json").write_text(content, encoding="utf-8")
+            (root / "cs.json").write_text(content, encoding="utf-8")
+
+            results = discover(root)
+
+        self.assert_discovery(
+            results,
+            [
+                {
+                    "filemask": "*.json",
+                    "file_format": "json-nested",
+                    "template": "en.json",
+                },
+            ],
         )
 
     def test_discover_files(self) -> None:

--- a/translation_finder/test_discovery.py
+++ b/translation_finder/test_discovery.py
@@ -1326,6 +1326,85 @@ class JSONDiscoveryTest(DiscoveryTestCase):
         self.assertIsNone(discovery.detect_dict({1: "Non-string key"}))
         self.assertIsNone(discovery.detect_dict({"outer": {"inner": 1}, "plain": 1}))
 
+    def test_nested_detection_deep_dict(self) -> None:
+        discovery = JSONDiscovery(self.get_finder([]))
+        nested: dict[str, object] = {"count_plural": "{{ count }} messages"}
+        for _ in range(2000):
+            nested = {"a": nested}
+
+        self.assertEqual(discovery.detect_dict(nested), "i18next")
+
+    def test_nested_detection_cyclic_dict(self) -> None:
+        discovery = JSONDiscovery(self.get_finder([]))
+        nested: dict[str, object] = {}
+        nested["a"] = nested
+
+        self.assertIsNone(discovery.detect_dict(nested))
+
+    def test_adjust_format_recursion_error_warning(self) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            tmppath = Path(tmpdir)
+            (tmppath / "en.json").write_text("{}", encoding="utf-8")
+            discovery = JSONDiscovery(Finder(tmppath))
+            result: ResultDict = {
+                "filemask": "*.json",
+                "file_format": "json-nested",
+                "template": "en.json",
+            }
+
+            with (
+                patch.object(
+                    files_module.json,
+                    "load",
+                    side_effect=RecursionError("too deep"),
+                ),
+                self.assertWarnsRegex(UserWarning, "Could not parse JSON: too deep"),
+            ):
+                discovery.adjust_format(result)
+
+        self.assertEqual(
+            result,
+            {
+                "filemask": "*.json",
+                "file_format": "json-nested",
+                "template": "en.json",
+            },
+        )
+
+    def test_read_json_data_recursion_error(self) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            tmppath = Path(tmpdir)
+            (tmppath / "en.json").write_text("{}", encoding="utf-8")
+            discovery = JSONDiscovery(Finder(tmppath))
+
+            with patch.object(
+                files_module.json,
+                "loads",
+                side_effect=RecursionError("too deep"),
+            ):
+                self.assertIsNone(discovery.read_json_data(Path("en.json")))
+
+    def test_deeply_nested_json_does_not_crash_discovery(self) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            tmppath = Path(tmpdir)
+            content = '{"a":' * 2000 + "1" + "}" * 2000
+            (tmppath / "en.json").write_text(content, encoding="utf-8")
+            (tmppath / "cs.json").write_text(content, encoding="utf-8")
+            discovery = JSONDiscovery(Finder(tmppath))
+
+            results = list(discovery.discover())
+
+        self.assert_discovery(
+            results,
+            [
+                {
+                    "filemask": "*.json",
+                    "file_format": "json-nested",
+                    "template": "en.json",
+                },
+            ],
+        )
+
     def test_template_less_bilingual_content(self) -> None:
         with tempfile.TemporaryDirectory() as tmpdir:
             tmppath = Path(tmpdir)


### PR DESCRIPTION
Catch RecursionError while parsing and detecting JSON formats so deeply nested repository files do not crash discovery. Add API and JSON discovery regression coverage.

<!--
♥ Thank you for submitting a pull request. ♥

We will review it in a timely manner, but please follow the CI checks to see
any problems it might discover.

Want to make a perfect pull request?

• Keep the pull request reasonably sized. Creating more pull requests is sometimes better.
• Describe what the pull request does and what issues it does address.
• Ensure that lint and unit tests pass.
• Add tests that prove that the fix is effective or that the new feature works.
• Describe any new features or changed behavior in the documentation.
-->
