### PR TITLE
fix: reject unsafe Transifex config paths

### DIFF
--- a/translation_finder/discovery/transifex.py
+++ b/translation_finder/discovery/transifex.py
@@ -9,6 +9,7 @@ from __future__ import annotations
 import re
 from configparser import Error as ConfigParserError
 from configparser import RawConfigParser
+from pathlib import PureWindowsPath
 from typing import TYPE_CHECKING, ClassVar
 
 from translation_finder.api import register_discovery
@@ -61,17 +62,35 @@ class TransifexDiscovery(BaseDiscovery):
         params = self.format_params.get(transifex)
         return file_format, params.copy() if params is not None else None
 
+    @staticmethod
+    def normalize_config_path(path: str) -> str:
+        """Normalize path separators used in Transifex configuration."""
+        return path.strip().replace("\\", "/")
+
+    @classmethod
+    def is_safe_config_path(cls, path: str) -> bool:
+        """Check whether a Transifex configuration path stays in the repository."""
+        normalized = cls.normalize_config_path(path)
+        return not (
+            normalized.startswith("/")
+            or PureWindowsPath(normalized).drive
+            or ".." in normalized.split("/")
+        )
+
     def extract_section(
         self, config: RawConfigParser, section: str
     ) -> ResultDict | None:
         """Extract single section from Transifex configuration."""
         if section == "main" or not config.has_option(section, "file_filter"):
             return None
+        filemask = self.normalize_config_path(
+            config.get(section, "file_filter").replace("<lang>", "*")
+        )
+        if not self.is_safe_config_path(filemask):
+            return None
         result: ResultDict = {
             "name": section,
-            "filemask": config.get(section, "file_filter")
-            .replace("<lang>", "*")
-            .replace("\\", "/"),
+            "filemask": filemask,
             "file_format": "",
         }
 
@@ -89,7 +108,9 @@ class TransifexDiscovery(BaseDiscovery):
             return None
 
         if config.has_option(section, "source_file"):
-            template = config.get(section, "source_file").replace("\\", "/")
+            template = self.normalize_config_path(config.get(section, "source_file"))
+            if not self.is_safe_config_path(template):
+                return None
             if template.lower().endswith(".pot"):
                 result["new_base"] = template
             else:

--- a/translation_finder/test_discovery.py
+++ b/translation_finder/test_discovery.py
@@ -1487,6 +1487,51 @@ type = PO
             },
         )
 
+    def test_reject_unsafe_file_filter(self) -> None:
+        discovery = TransifexDiscovery(self.get_finder([]))
+        for file_filter in (
+            "../../*.po",
+            "/absolute/*.po",
+            "C:/tmp/*.po",
+            "C:tmp/*.po",
+            "..\\..\\*.po",
+            "\n    /absolute/*.po",
+            "\n    ../../*.po",
+        ):
+            with self.subTest(file_filter=file_filter):
+                config = RawConfigParser()
+                config.read_string(
+                    f"""
+[unsafe]
+file_filter = {file_filter}
+type = PO
+"""
+                )
+                self.assertIsNone(discovery.extract_section(config, "unsafe"))
+
+    def test_reject_unsafe_source_file(self) -> None:
+        discovery = TransifexDiscovery(self.get_finder([]))
+        for source_file in (
+            "../../messages.pot",
+            "/etc/passwd",
+            "C:/tmp/messages.pot",
+            "C:tmp/messages.pot",
+            "..\\..\\messages.pot",
+            "\n    /etc/passwd",
+            "\n    ../../messages.pot",
+        ):
+            with self.subTest(source_file=source_file):
+                config = RawConfigParser()
+                config.read_string(
+                    f"""
+[unsafe]
+file_filter = locales/<lang>.po
+source_file = {source_file}
+type = PO
+"""
+                )
+                self.assertIsNone(discovery.extract_section(config, "unsafe"))
+
     def test_po_source_file(self) -> None:
         config = RawConfigParser()
         config.read_string(


### PR DESCRIPTION
Reject absolute, drive-prefixed, and parent-directory paths from .tx/config discovery results.

Add regression tests for unsafe file_filter and source_file values.

<!--
♥ Thank you for submitting a pull request. ♥

We will review it in a timely manner, but please follow the CI checks to see
any problems it might discover.

Want to make a perfect pull request?

• Keep the pull request reasonably sized. Creating more pull requests is sometimes better.
• Describe what the pull request does and what issues it does address.
• Ensure that lint and unit tests pass.
• Add tests that prove that the fix is effective or that the new feature works.
• Describe any new features or changed behavior in the documentation.
-->
