### PR TITLE
fix: limit format sniffing reads

### DIFF
--- a/translation_finder/discovery/files.py
+++ b/translation_finder/discovery/files.py
@@ -35,7 +35,9 @@ if TYPE_CHECKING:
     from .result import DiscoveryResult, ResultDict
 
 LARAVEL_RE = re.compile(r"=>.*\|")
+LARAVEL_BYTES_RE = re.compile(rb"=>.*\|")
 GWT_PLURAL_RE = re.compile(r"^[^#!\s][^:=\n]*\[[a-zA-Z_]+\]\s*[:=]", re.MULTILINE)
+FORMAT_SNIFF_MAX_BYTES = 1024 * 1024
 CSV_SAMPLE_ROWS = 100
 SIMPLE_CSV_COLUMNS = 2
 YAML_INSPECTION_MAX_DEPTH = 128
@@ -64,14 +66,104 @@ def _decode_content(content: bytes) -> str:
     return content.decode("iso-8859-1")
 
 
-def _read_text_sample(finder: Finder, path: PurePath, size: int = 65536) -> str | None:
-    """Read a text sample from a real finder path."""
+def _decode_sample_content(content: bytes) -> str:
+    """Decode sampled file content, ignoring incomplete trailing bytes."""
+    try:
+        return content.decode("utf-8-sig")
+    except UnicodeDecodeError as error:
+        if error.end == len(content) and error.reason == "unexpected end of data":
+            return content[: error.start].decode("utf-8-sig")
+
+    if content.startswith((b"\xff\xfe", b"\xfe\xff")):
+        try:
+            return content.decode("utf-16")
+        except UnicodeDecodeError as error:
+            if error.end == len(content) and error.reason == "truncated data":
+                return content[: error.start].decode("utf-16")
+
+    return content.decode("iso-8859-1")
+
+
+def _read_binary_sample(
+    finder: Finder,
+    path: PurePath,
+    size: int | None = None,
+) -> bytes | None:
+    """Read a bounded binary sample from a real finder path."""
+    if size is None:
+        size = FORMAT_SNIFF_MAX_BYTES
     if not hasattr(path, "open"):
         return None
     try:
         with finder.open(path, "rb") as handle:
-            content = handle.read(size)
+            return handle.read(size)
     except OSError:
+        return None
+
+
+def _read_binary_sniff_sample(
+    finder: Finder,
+    path: PurePath,
+    size: int | None = None,
+) -> tuple[bytes, bool] | None:
+    """Read a bounded binary sample and report whether it is the complete file."""
+    if size is None:
+        size = FORMAT_SNIFF_MAX_BYTES
+    if not hasattr(path, "open"):
+        return None
+    try:
+        with finder.open(path, "rb") as handle:
+            content = handle.read(size + 1)
+    except OSError:
+        return None
+    return content[:size], len(content) <= size
+
+
+def _read_binary_sniff_content(
+    finder: Finder,
+    path: PurePath,
+    size: int | None = None,
+) -> bytes | None:
+    """Read complete content only when it fits within the sniffing limit."""
+    sample = _read_binary_sniff_sample(finder, path, size)
+    if sample is None:
+        return None
+    content, complete = sample
+    if not complete:
+        return None
+    return content
+
+
+def _is_sniff_content_over_limit(
+    finder: Finder,
+    path: PurePath,
+    size: int | None = None,
+) -> bool:
+    """Check whether sniffing skipped content because it exceeded the limit."""
+    sample = _read_binary_sniff_sample(finder, path, size)
+    return sample is not None and not sample[1]
+
+
+def _read_text_sample(
+    finder: Finder,
+    path: PurePath,
+    size: int | None = None,
+) -> str | None:
+    """Read a text sample from a real finder path."""
+    content = _read_binary_sample(finder, path, size)
+    if content is None:
+        return None
+    return _decode_sample_content(content)
+
+
+def _read_text_sniff_content(
+    finder: Finder,
+    path: PurePath,
+    size: int | None = None,
+) -> str | None:
+    """Read complete text content only when it fits within the sniffing limit."""
+    content = _read_binary_sniff_content(finder, path, size)
+    if content is None:
         return None
     return _decode_content(content)
 
@@ -239,24 +331,26 @@ class XliffDiscovery(BaseDiscovery):
         if not hasattr(path, "open"):
             return
 
-        with self.finder.open(path, "r") as handle:
-            content = handle.read()
-            # Check for XLIFF 2.0 first
-            if 'version="2.0"' in content or 'version="2.1"' in content:
-                if "<pc" in content or "<sc" in content or "<ec" in content:
-                    result["file_format"] = "xliff2-placeables"
-                else:
-                    result["file_format"] = "xliff2"
-            elif 'restype="x-gettext' in content:
-                result["file_format"] = "poxliff"
-            elif (
-                "NSStringPluralRuleType" in content
-                or 'original="Localizable.strings"' in content
-                or ":dict" in content
-            ):
-                result["file_format"] = "apple-xliff"
-            elif "<x " not in content and "<g " not in content:
-                result["file_format"] = "plainxliff"
+        sample = _read_binary_sniff_sample(self.finder, path)
+        if sample is None:
+            return
+        content, _complete = sample
+        # Check for XLIFF 2.0 first
+        if b'version="2.0"' in content or b'version="2.1"' in content:
+            if b"<pc" in content or b"<sc" in content or b"<ec" in content:
+                result["file_format"] = "xliff2-placeables"
+            else:
+                result["file_format"] = "xliff2"
+        elif b'restype="x-gettext' in content:
+            result["file_format"] = "poxliff"
+        elif (
+            b"NSStringPluralRuleType" in content
+            or b'original="Localizable.strings"' in content
+            or b":dict" in content
+        ):
+            result["file_format"] = "apple-xliff"
+        elif b"<x " not in content and b"<g " not in content:
+            result["file_format"] = "plainxliff"
 
 
 @register_discovery
@@ -338,10 +432,9 @@ class AndroidDiscovery(BaseDiscovery):
         if not hasattr(path, "open"):
             return
 
-        with self.finder.open(path, "r") as handle:
-            content = handle.read()
-            if "<plural " in content:
-                result["file_format"] = "moko-resource"
+        content = _read_binary_sample(self.finder, path)
+        if content is not None and b"<plural " in content:
+            result["file_format"] = "moko-resource"
 
 
 @register_discovery
@@ -546,9 +639,11 @@ class JSONDiscovery(BaseDiscovery):
 
     def read_json_data(self, path: PurePath) -> object | None:
         """Read and parse a complete JSON file."""
+        content = _read_binary_sniff_content(self.finder, path)
+        if content is None:
+            return None
         try:
-            with self.finder.open(path, "rb") as handle:
-                return json.loads(_decode_content(handle.read()))
+            return json.loads(_decode_content(content))
         except (OSError, RecursionError, ValueError):
             return None
 
@@ -556,6 +651,9 @@ class JSONDiscovery(BaseDiscovery):
         """Check whether a template-less JSON result looks translatable."""
         for path in _iter_result_paths(self.finder, result):
             if not hasattr(path, "open"):
+                return True
+
+            if _is_sniff_content_over_limit(self.finder, path):
                 return True
 
             data = self.read_json_data(path)
@@ -697,22 +795,24 @@ class JSONDiscovery(BaseDiscovery):
         if not hasattr(path, "open"):
             return
 
-        with self.finder.open(path, "r") as handle:
-            try:
-                data = json.load(handle)
-            except (RecursionError, ValueError) as error:
-                warnings.warn(f"Could not parse JSON: {error}", stacklevel=0)
-                return
-            if isinstance(data, list) and len(data) > 0 and "id" in data[0]:
-                result["file_format"] = "go-i18n-json"
-                return
-            if not isinstance(data, dict):
-                return
+        content = _read_binary_sniff_content(self.finder, path)
+        if content is None:
+            return
+        try:
+            data = json.loads(content.decode())
+        except (RecursionError, UnicodeError, ValueError) as error:
+            warnings.warn(f"Could not parse JSON: {error}", stacklevel=0)
+            return
+        if isinstance(data, list) and len(data) > 0 and "id" in data[0]:
+            result["file_format"] = "go-i18n-json"
+            return
+        if not isinstance(data, dict):
+            return
 
-            detected = self.detect_dict(data)
+        detected = self.detect_dict(data)
 
-            if detected is not None:
-                result["file_format"] = detected
+        if detected is not None:
+            result["file_format"] = detected
 
 
 @register_discovery
@@ -747,25 +847,27 @@ class YAMLDiscovery(BaseDiscovery):
         if not hasattr(path, "open"):
             return
 
-        with self.finder.open(path, "rb") as handle:
-            yaml = YAML()
-            yaml.max_depth = YAML_INSPECTION_MAX_DEPTH
-            try:
-                data = yaml.load(handle)
-            except (YAMLError, YAMLFutureWarning):
-                return
-            except (OSError, UnicodeError, TypeError, ValueError) as error:
-                # Weird errors can happen when parsing YAML, handle them gracefully, but
-                # emit a warning
-                warnings.warn(f"Could not parse YAML: {error}", stacklevel=0)
-                return
-            if isinstance(data, dict) and len(data) == 1:
-                key = cast("str", next(iter(data.keys())))
-                if "filemask" in result:
-                    if result["filemask"].replace("*", key) == result["template"]:
-                        result["file_format"] = "ruby-yaml"
-                elif key in result["template"]:
+        content = _read_text_sniff_content(self.finder, path)
+        if content is None:
+            return
+        yaml = YAML()
+        yaml.max_depth = YAML_INSPECTION_MAX_DEPTH
+        try:
+            data = yaml.load(content)
+        except (YAMLError, YAMLFutureWarning):
+            return
+        except (OSError, UnicodeError, TypeError, ValueError) as error:
+            # Weird errors can happen when parsing YAML, handle them gracefully, but
+            # emit a warning
+            warnings.warn(f"Could not parse YAML: {error}", stacklevel=0)
+            return
+        if isinstance(data, dict) and len(data) == 1:
+            key = cast("str", next(iter(data.keys())))
+            if "filemask" in result:
+                if result["filemask"].replace("*", key) == result["template"]:
                     result["file_format"] = "ruby-yaml"
+            elif key in result["template"]:
+                result["file_format"] = "ruby-yaml"
 
 
 @register_discovery
@@ -817,10 +919,13 @@ class PHPDiscovery(MonoTemplateDiscovery):
         if not hasattr(path, "open"):
             return
 
-        with self.finder.open(path, "r") as handle:
-            content = handle.read()
-            if "return [" in content and LARAVEL_RE.search(content):
-                result["file_format"] = "laravel"
+        content = _read_binary_sample(self.finder, path)
+        if (
+            content is not None
+            and b"return [" in content
+            and LARAVEL_BYTES_RE.search(content)
+        ):
+            result["file_format"] = "laravel"
 
 
 @register_discovery
@@ -924,21 +1029,23 @@ class TOMLDiscovery(BaseDiscovery):
         if not hasattr(path, "open"):
             return
 
-        with self.finder.open(path, "rb") as handle:
-            try:
-                data = tomllib.load(handle)
-            except (tomllib.TOMLDecodeError, OSError) as error:
-                warnings.warn(f"Could not parse TOML: {error}", stacklevel=0)
-                return
-            # go-i18n-toml detection - has messages array with 'id' field
-            messages = data.get("messages") if isinstance(data, dict) else None
-            if (
-                isinstance(messages, list)
-                and len(messages) > 0
-                and isinstance(messages[0], dict)
-                and "id" in messages[0]
-            ):
-                result["file_format"] = "go-i18n-toml"
+        content = _read_text_sniff_content(self.finder, path)
+        if content is None:
+            return
+        try:
+            data = tomllib.loads(content)
+        except (tomllib.TOMLDecodeError, OSError) as error:
+            warnings.warn(f"Could not parse TOML: {error}", stacklevel=0)
+            return
+        # go-i18n-toml detection - has messages array with 'id' field
+        messages = data.get("messages") if isinstance(data, dict) else None
+        if (
+            isinstance(messages, list)
+            and len(messages) > 0
+            and isinstance(messages[0], dict)
+            and "id" in messages[0]
+        ):
+            result["file_format"] = "go-i18n-toml"
 
 
 @register_discovery

--- a/translation_finder/test_discovery.py
+++ b/translation_finder/test_discovery.py
@@ -1356,7 +1356,7 @@ class JSONDiscoveryTest(DiscoveryTestCase):
             with (
                 patch.object(
                     files_module.json,
-                    "load",
+                    "loads",
                     side_effect=RecursionError("too deep"),
                 ),
                 self.assertWarnsRegex(UserWarning, "Could not parse JSON: too deep"),
@@ -1828,6 +1828,31 @@ class YAMLDiscoveryTest(DiscoveryTestCase):
 
         self.assertNotIn("file_format", result)
 
+    def test_ruby_yaml_with_filemask(self) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            tmppath = Path(tmpdir)
+            (tmppath / "en.yml").write_text("en:\n  hello: world\n")
+            discovery = YAMLDiscovery(Finder(tmppath))
+            result: ResultDict = {"filemask": "*.yml", "template": "en.yml"}
+
+            discovery.adjust_format(result)
+
+        self.assertEqual(result["file_format"], "ruby-yaml")
+
+    def test_parser_error_is_ignored(self) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            tmppath = Path(tmpdir)
+            (tmppath / "en.yml").write_text("en:\n  hello: world\n")
+            discovery = YAMLDiscovery(Finder(tmppath))
+            result: ResultDict = {"filemask": "*.yml", "template": "en.yml"}
+
+            with patch.object(
+                files_module.YAML, "load", side_effect=files_module.YAMLError
+            ):
+                discovery.adjust_format(result)
+
+        self.assertNotIn("file_format", result)
+
     def test_multi_key_yaml_keeps_format(self) -> None:
         with tempfile.TemporaryDirectory() as tmpdir:
             tmppath = Path(tmpdir)
@@ -2149,6 +2174,326 @@ class CSVHelperTest(DiscoveryTestCase):
 
     def test_csv_simple_rejects_non_two_column_rows(self) -> None:
         self.assertFalse(files_module._is_csv_simple([["source", "target", "extra"]]))
+
+
+class FormatSniffLimitTest(DiscoveryTestCase):
+    def test_text_sample_uses_shared_limit(self) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            tmppath = Path(tmpdir)
+            (tmppath / "sample.txt").write_text("abcdef", encoding="utf-8")
+            finder = Finder(tmppath)
+            path = next(finder.mask_matches("sample.txt"))
+
+            with patch.object(files_module, "FORMAT_SNIFF_MAX_BYTES", 4):
+                self.assertEqual(files_module._read_text_sample(finder, path), "abcd")
+                self.assertIsNone(files_module._read_text_sniff_content(finder, path))
+
+    def test_sniff_content_accepts_exact_limit(self) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            tmppath = Path(tmpdir)
+            (tmppath / "sample.txt").write_text("abcd", encoding="utf-8")
+            finder = Finder(tmppath)
+            path = next(finder.mask_matches("sample.txt"))
+
+            with patch.object(files_module, "FORMAT_SNIFF_MAX_BYTES", 4):
+                self.assertEqual(
+                    files_module._read_binary_sniff_content(finder, path), b"abcd"
+                )
+                self.assertEqual(
+                    files_module._read_text_sniff_content(finder, path), "abcd"
+                )
+
+    def test_binary_sniff_sample_reports_incomplete_files(self) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            tmppath = Path(tmpdir)
+            (tmppath / "sample.txt").write_text("abcdef", encoding="utf-8")
+            finder = Finder(tmppath)
+            path = next(finder.mask_matches("sample.txt"))
+
+            with patch.object(files_module, "FORMAT_SNIFF_MAX_BYTES", 4):
+                self.assertEqual(
+                    files_module._read_binary_sniff_sample(finder, path),
+                    (b"abcd", False),
+                )
+
+    def test_binary_sniff_sample_open_error(self) -> None:
+        class FailingFinder:
+            @staticmethod
+            def open(_path: Path, _mode: str = "rb") -> None:
+                raise OSError
+
+        finder = self.get_finder([])
+
+        self.assertIsNone(
+            files_module._read_binary_sniff_sample(finder, PurePath("missing.txt"))
+        )
+        self.assertIsNone(
+            files_module._read_binary_sniff_sample(
+                cast("Finder", FailingFinder()),
+                Path("missing.txt"),
+            )
+        )
+        self.assertIsNone(
+            files_module._read_binary_sniff_content(
+                cast("Finder", FailingFinder()),
+                Path("missing.txt"),
+            )
+        )
+        self.assertFalse(
+            files_module._is_sniff_content_over_limit(
+                cast("Finder", FailingFinder()),
+                Path("missing.txt"),
+            )
+        )
+
+    def test_sniff_content_over_limit(self) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            tmppath = Path(tmpdir)
+            (tmppath / "sample.txt").write_text("abcdef", encoding="utf-8")
+            finder = Finder(tmppath)
+            path = next(finder.mask_matches("sample.txt"))
+
+            with patch.object(files_module, "FORMAT_SNIFF_MAX_BYTES", 4):
+                self.assertTrue(files_module._is_sniff_content_over_limit(finder, path))
+
+    def test_sample_decode_fallbacks(self) -> None:
+        self.assertEqual(files_module._decode_sample_content(b"\xff"), "\u00ff")
+        self.assertEqual(
+            files_module._decode_sample_content(b"\xff\xfeA\x00B"),
+            "A",
+        )
+
+    def test_text_sample_ignores_truncated_utf8_character(self) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            tmppath = Path(tmpdir)
+            (tmppath / "sample.txt").write_text("abc€", encoding="utf-8")
+            finder = Finder(tmppath)
+            path = next(finder.mask_matches("sample.txt"))
+
+            self.assertEqual(files_module._read_text_sample(finder, path, 4), "abc")
+
+    def test_large_xliff_uses_sample_for_content_refinement(self) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            tmppath = Path(tmpdir)
+            content = '<xliff version="2.0">' + "x" * 64
+            (tmppath / "en.xliff").write_text(content, encoding="utf-8")
+            discovery = XliffDiscovery(Finder(tmppath))
+            result: ResultDict = {
+                "filemask": "*.xliff",
+                "file_format": "xliff",
+                "template": "en.xliff",
+            }
+
+            with patch.object(files_module, "FORMAT_SNIFF_MAX_BYTES", 32):
+                discovery.adjust_format(result)
+
+        self.assertEqual(result["file_format"], "xliff2")
+
+    def test_large_xliff_uses_sample_for_negative_refinement(self) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            tmppath = Path(tmpdir)
+            content = "<xliff><file><body>" + "x" * 64
+            (tmppath / "en.xliff").write_text(content, encoding="utf-8")
+            discovery = XliffDiscovery(Finder(tmppath))
+            result: ResultDict = {
+                "filemask": "*.xliff",
+                "file_format": "xliff",
+                "template": "en.xliff",
+            }
+
+            with patch.object(files_module, "FORMAT_SNIFF_MAX_BYTES", 32):
+                discovery.adjust_format(result)
+
+        self.assertEqual(result["file_format"], "plainxliff")
+
+    def test_xliff_skips_missing_sample(self) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            tmppath = Path(tmpdir)
+            (tmppath / "en.xliff").write_text("<xliff></xliff>", encoding="utf-8")
+            discovery = XliffDiscovery(Finder(tmppath))
+            result: ResultDict = {
+                "filemask": "*.xliff",
+                "file_format": "xliff",
+                "template": "en.xliff",
+            }
+
+            with patch.object(
+                files_module, "_read_binary_sniff_sample", return_value=None
+            ):
+                discovery.adjust_format(result)
+
+        self.assertEqual(result["file_format"], "xliff")
+
+    def test_large_json_template_skips_content_refinement(self) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            tmppath = Path(tmpdir)
+            content = json.dumps(
+                {"hash": "sha1-abc", "message": "Hello", "padding": "x" * 64}
+            )
+            (tmppath / "en.json").write_text(content, encoding="utf-8")
+            discovery = JSONDiscovery(Finder(tmppath))
+            result: ResultDict = {
+                "filemask": "*.json",
+                "file_format": "json-nested",
+                "template": "en.json",
+            }
+
+            with (
+                patch.object(files_module, "FORMAT_SNIFF_MAX_BYTES", 32),
+                patch.object(
+                    files_module.json,
+                    "loads",
+                    side_effect=AssertionError("parser should not run"),
+                ),
+            ):
+                discovery.adjust_format(result)
+
+        self.assertEqual(result["file_format"], "json-nested")
+
+    def test_large_json_read_json_data_skips_parsing(self) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            tmppath = Path(tmpdir)
+            content = json.dumps({"Hello": "Ahoj", "padding": "x" * 64})
+            (tmppath / "bi-cs.json").write_text(content, encoding="utf-8")
+            discovery = JSONDiscovery(Finder(tmppath))
+
+            with patch.object(files_module, "FORMAT_SNIFF_MAX_BYTES", 32):
+                self.assertIsNone(discovery.read_json_data(Path("bi-cs.json")))
+
+    def test_large_template_less_json_keeps_generic_discovery(self) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            tmppath = Path(tmpdir)
+            content = json.dumps({"Hello": "Ahoj", "padding": "x" * 64})
+            (tmppath / "bi-cs.json").write_text(content, encoding="utf-8")
+            discovery = JSONDiscovery(Finder(tmppath))
+
+            with (
+                patch.object(files_module, "FORMAT_SNIFF_MAX_BYTES", 32),
+                patch.object(
+                    files_module.json,
+                    "loads",
+                    side_effect=AssertionError("parser should not run"),
+                ),
+            ):
+                results = list(discovery.discover())
+
+        self.assert_discovery(
+            results,
+            [{"filemask": "bi-*.json", "file_format": "json-nested"}],
+        )
+
+    def test_large_yaml_skips_content_refinement(self) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            tmppath = Path(tmpdir)
+            (tmppath / "en.yml").write_text(
+                "en:\n  hello: world\n" + "# padding\n" * 8,
+                encoding="utf-8",
+            )
+            discovery = YAMLDiscovery(Finder(tmppath))
+            result: ResultDict = {
+                "filemask": "*.yml",
+                "file_format": "yaml",
+                "template": "en.yml",
+            }
+
+            with (
+                patch.object(files_module, "FORMAT_SNIFF_MAX_BYTES", 32),
+                patch.object(
+                    files_module.YAML,
+                    "load",
+                    side_effect=AssertionError("parser should not run"),
+                ),
+            ):
+                discovery.adjust_format(result)
+
+        self.assertEqual(result["file_format"], "yaml")
+
+    def test_large_php_skips_content_refinement(self) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            tmppath = Path(tmpdir)
+            (tmppath / "en.php").write_text(
+                "<?php\nreturn [\n    'items' => 'one|many',\n];\n"
+                + "// padding\n" * 8,
+                encoding="utf-8",
+            )
+            discovery = PHPDiscovery(Finder(tmppath))
+            result: ResultDict = {
+                "filemask": "*.php",
+                "file_format": "php",
+                "template": "en.php",
+            }
+
+            with patch.object(files_module, "FORMAT_SNIFF_MAX_BYTES", 32):
+                discovery.adjust_format(result)
+
+        self.assertEqual(result["file_format"], "php")
+
+    def test_large_php_uses_sample_for_content_refinement(self) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            tmppath = Path(tmpdir)
+            (tmppath / "en.php").write_text(
+                "<?php return ['items' => 'one|many'];\n" + "// padding\n" * 8,
+                encoding="utf-8",
+            )
+            discovery = PHPDiscovery(Finder(tmppath))
+            result: ResultDict = {
+                "filemask": "*.php",
+                "file_format": "php",
+                "template": "en.php",
+            }
+
+            with patch.object(files_module, "FORMAT_SNIFF_MAX_BYTES", 40):
+                discovery.adjust_format(result)
+
+        self.assertEqual(result["file_format"], "laravel")
+
+    def test_large_android_uses_sample_for_content_refinement(self) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            tmppath = Path(tmpdir)
+            (tmppath / "app/src/res/main/values").mkdir(parents=True)
+            (tmppath / "app/src/res/main/values/strings.xml").write_text(
+                '<resources><plural name="items"></plural></resources>'
+                + "<!-- padding -->" * 8,
+                encoding="utf-8",
+            )
+            discovery = AndroidDiscovery(Finder(tmppath))
+            result: ResultDict = {
+                "filemask": "app/src/res/main/values-*/strings.xml",
+                "file_format": "aresource",
+                "template": "app/src/res/main/values/strings.xml",
+            }
+
+            with patch.object(files_module, "FORMAT_SNIFF_MAX_BYTES", 32):
+                discovery.adjust_format(result)
+
+        self.assertEqual(result["file_format"], "moko-resource")
+
+    def test_large_toml_skips_content_refinement(self) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            tmppath = Path(tmpdir)
+            (tmppath / "en.toml").write_text(
+                '[[messages]]\nid = "hello"\ntranslation = "Hello"\n'
+                + "# padding\n" * 8,
+                encoding="utf-8",
+            )
+            discovery = TOMLDiscovery(Finder(tmppath))
+            result: ResultDict = {
+                "filemask": "*.toml",
+                "file_format": "toml",
+                "template": "en.toml",
+            }
+
+            with (
+                patch.object(files_module, "FORMAT_SNIFF_MAX_BYTES", 32),
+                patch.object(
+                    files_module.tomllib,
+                    "loads",
+                    side_effect=AssertionError("parser should not run"),
+                ),
+            ):
+                discovery.adjust_format(result)
+
+        self.assertEqual(result["file_format"], "toml")
 
 
 class PHPDiscoveryTest(DiscoveryTestCase):


### PR DESCRIPTION
Add shared capped read helpers for format detection and skip parser-based refinement for oversized files. Keep byte-sample marker sniffing for formats that support partial content.

<!--
♥ Thank you for submitting a pull request. ♥

We will review it in a timely manner, but please follow the CI checks to see
any problems it might discover.

Want to make a perfect pull request?

• Keep the pull request reasonably sized. Creating more pull requests is sometimes better.
• Describe what the pull request does and what issues it does address.
• Ensure that lint and unit tests pass.
• Add tests that prove that the fix is effective or that the new feature works.
• Describe any new features or changed behavior in the documentation.
-->
