### PR TITLE
fix: limit YAML inspection depth

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,7 +22,7 @@ classifiers = [
 ]
 dependencies = [
   "charset-normalizer>2.0,<4.0",
-  "ruamel.yaml",
+  "ruamel.yaml>=0.19.1",
   "weblate-language-data>=2026.8"
 ]
 description = "A translation file finder used in Weblate."

--- a/translation_finder/discovery/files.py
+++ b/translation_finder/discovery/files.py
@@ -38,6 +38,7 @@ LARAVEL_RE = re.compile(r"=>.*\|")
 GWT_PLURAL_RE = re.compile(r"^[^#!\s][^:=\n]*\[[a-zA-Z_]+\]\s*[:=]", re.MULTILINE)
 CSV_SAMPLE_ROWS = 100
 SIMPLE_CSV_COLUMNS = 2
+YAML_INSPECTION_MAX_DEPTH = 128
 CSV_FIELDNAMES = {
     "context",
     "developer_comments",
@@ -748,6 +749,7 @@ class YAMLDiscovery(BaseDiscovery):
 
         with self.finder.open(path, "rb") as handle:
             yaml = YAML()
+            yaml.max_depth = YAML_INSPECTION_MAX_DEPTH
             try:
                 data = yaml.load(handle)
             except (YAMLError, YAMLFutureWarning):

--- a/translation_finder/test_discovery.py
+++ b/translation_finder/test_discovery.py
@@ -20,6 +20,7 @@ from .discovery import base as base_module
 from .discovery import files as files_module
 from .discovery.base import DiscoveryResult
 from .discovery.files import (
+    YAML_INSPECTION_MAX_DEPTH,
     AndroidDiscovery,
     AppStoreDiscovery,
     ARBDiscovery,
@@ -1838,6 +1839,27 @@ class YAMLDiscoveryTest(DiscoveryTestCase):
                 discovery.discover(),
                 [{"filemask": "*.yml", "file_format": "yaml", "template": "en.yml"}],
             )
+
+    def test_deep_yaml_keeps_format(self) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            tmppath = Path(tmpdir)
+            lines = ["en:"]
+            lines.extend(
+                f"{'  ' * (depth + 1)}level_{depth}:"
+                for depth in range(YAML_INSPECTION_MAX_DEPTH + 1)
+            )
+            lines.append(f"{'  ' * (YAML_INSPECTION_MAX_DEPTH + 2)}leaf: value")
+            (tmppath / "en.yml").write_text("\n".join(lines))
+
+            discovery = YAMLDiscovery(Finder(tmppath))
+            result: ResultDict = {
+                "filemask": "*.yml",
+                "file_format": "yaml",
+                "template": "en.yml",
+            }
+            discovery.adjust_format(result)
+
+        self.assertEqual(result["file_format"], "yaml")
 
 
 class TOMLDiscoveryTest(DiscoveryTestCase):


### PR DESCRIPTION
Use ruamel.yaml max_depth when inspecting YAML files and require a version that supports it.

<!--
♥ Thank you for submitting a pull request. ♥

We will review it in a timely manner, but please follow the CI checks to see
any problems it might discover.

Want to make a perfect pull request?

• Keep the pull request reasonably sized. Creating more pull requests is sometimes better.
• Describe what the pull request does and what issues it does address.
• Ensure that lint and unit tests pass.
• Add tests that prove that the fix is effective or that the new feature works.
• Describe any new features or changed behavior in the documentation.
-->
