### PR TITLE
test: fuzz discovery file contents

### DIFF
--- a/translation_finder/test_fuzz.py
+++ b/translation_finder/test_fuzz.py
@@ -5,7 +5,10 @@
 
 from __future__ import annotations
 
-from pathlib import PurePath
+import json
+import tempfile
+import warnings
+from pathlib import Path, PurePath
 from typing import TYPE_CHECKING
 from unittest import TestCase
 
@@ -63,6 +66,10 @@ NAME_TOKEN = st.text(
     min_size=1,
     max_size=12,
 )
+CONTENT_VALUE = st.text(
+    alphabet="abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789 _-{}[]<>/=:,.;\n\t|@",
+    max_size=80,
+)
 DIRECTORY = st.one_of(
     st.sampled_from(("app", "i18n", "locale", "locales", "po", "resources", "src")),
     NAME_TOKEN,
@@ -76,6 +83,8 @@ STRING_RESULT_FIELDS = (
     "new_base",
     "template",
 )
+FileContent = str | bytes
+FileSet = dict[str, FileContent]
 
 
 @st.composite
@@ -115,6 +124,212 @@ def path_name(draw: st.DrawFn) -> str:
 
 
 PATH_NAMES = st.lists(path_name(), min_size=1, max_size=16, unique=True)
+
+
+def language_pair(directory: str, extension: str, content: FileContent) -> FileSet:
+    """Build source and target files for template-based discovery."""
+    return {
+        f"{directory}/en.{extension}": content,
+        f"{directory}/cs.{extension}": content,
+    }
+
+
+def json_files(draw: st.DrawFn) -> FileSet:
+    """Generate JSON files with valid or invalid translation-like content."""
+    key = draw(NAME_TOKEN)
+    value = draw(CONTENT_VALUE)
+    variant = draw(st.sampled_from(("flat", "go", "invalid", "nested", "webext")))
+
+    if variant == "flat":
+        content: FileContent = json.dumps({key: value})
+    elif variant == "go":
+        content = json.dumps([{"id": key, "translation": value}])
+    elif variant == "nested":
+        content = json.dumps({key: {"message": value}})
+    elif variant == "webext":
+        content = json.dumps({key: {"description": value, "message": value}})
+    else:
+        content = value
+
+    if draw(st.booleans()):
+        content = b"\xef\xbb\xbf" + str(content).encode()
+    return language_pair("json", "json", content)
+
+
+def yaml_files(draw: st.DrawFn) -> FileSet:
+    """Generate YAML files with valid or malformed content."""
+    key = draw(NAME_TOKEN)
+    value = draw(CONTENT_VALUE)
+    content = draw(
+        st.sampled_from(
+            (
+                f"en:\n  {key}: {value!r}\n",
+                f"{key}: {value!r}\n",
+                f"en: {value!r}\ncs: {value!r}\n",
+                "[broken\n",
+            ),
+        ),
+    )
+    return language_pair("yaml", "yml", content)
+
+
+def toml_files(draw: st.DrawFn) -> FileSet:
+    """Generate TOML files with valid or malformed content."""
+    key = draw(NAME_TOKEN)
+    value = draw(CONTENT_VALUE)
+    content = draw(
+        st.sampled_from(
+            (
+                f"{key} = {json.dumps(value)}\n",
+                f'[[messages]]\nid = "{key}"\nmessage = {json.dumps(value)}\n',
+                "[broken\n",
+            ),
+        ),
+    )
+    return language_pair("toml", "toml", content)
+
+
+def csv_files(draw: st.DrawFn) -> FileSet:
+    """Generate CSV files with simple and multivalue shapes."""
+    key = draw(NAME_TOKEN)
+    value = draw(CONTENT_VALUE)
+    content = draw(
+        st.sampled_from(
+            (
+                f"{key},{value}\n",
+                f"context,source,target\n{key},{value},{value}\n",
+                f"context,source,target\n{key},{value},{value}\n{key},{value},other\n",
+                value,
+            ),
+        ),
+    )
+    return language_pair("csv", "csv", content)
+
+
+def php_files(draw: st.DrawFn) -> FileSet:
+    """Generate PHP translation files."""
+    key = draw(NAME_TOKEN)
+    value = draw(CONTENT_VALUE)
+    content = draw(
+        st.sampled_from(
+            (
+                f"<?php\nreturn ['{key}' => '{value}|other'];\n",
+                f"<?php\nreturn [{key!r} => {value!r}];\n",
+                value,
+            ),
+        ),
+    )
+    return language_pair("php", "php", content)
+
+
+def properties_files(draw: st.DrawFn) -> FileSet:
+    """Generate Java properties files."""
+    key = draw(NAME_TOKEN)
+    value = draw(CONTENT_VALUE)
+    content = draw(
+        st.sampled_from(
+            (
+                f"{key}={value}\n",
+                f"{key}[one]=one\n{key}[other]=other\n",
+                f"# XWiki\n{key}={value}\n",
+                value,
+            ),
+        ),
+    )
+    return {
+        "java/messages.properties": content,
+        "java/messages_cs.properties": content,
+    }
+
+
+def xliff_files(draw: st.DrawFn) -> FileSet:
+    """Generate XLIFF-like files."""
+    value = draw(CONTENT_VALUE)
+    content = draw(
+        st.sampled_from(
+            (
+                f'<xliff version="2.0"><file><unit><segment>{value}</segment></unit></file></xliff>',
+                '<xliff version="2.1"><pc>wrapped</pc></xliff>',
+                '<xliff><file original="Localizable.strings"></file></xliff>',
+                f"<xliff>{value}</xliff>",
+            ),
+        ),
+    )
+    return language_pair("xliff", "xliff", content)
+
+
+def android_files(draw: st.DrawFn) -> FileSet:
+    """Generate Android resource files."""
+    key = draw(NAME_TOKEN)
+    value = draw(CONTENT_VALUE)
+    content = draw(
+        st.sampled_from(
+            (
+                f'<resources><string name="{key}">{value}</string></resources>',
+                '<resources><plural name="count"><item quantity="one">One</item></plural></resources>',
+                value,
+            ),
+        ),
+    )
+    return {
+        "app/src/main/res/values/strings.xml": content,
+        "app/src/main/res/values-cs/strings.xml": content,
+    }
+
+
+def flat_xml_files(draw: st.DrawFn) -> FileSet:
+    """Generate flat XML files."""
+    value = draw(CONTENT_VALUE)
+    content = draw(
+        st.sampled_from(
+            (
+                "<xwikidoc><syntaxId>plain/1.0</syntaxId></xwikidoc>",
+                "<xwikidoc><syntaxId>xwiki/2.1</syntaxId></xwikidoc>",
+                f"<root>{value}</root>",
+            ),
+        ),
+    )
+    return language_pair("xml", "xml", content)
+
+
+def transifex_files(draw: st.DrawFn) -> FileSet:
+    """Generate Transifex configuration files."""
+    key = draw(NAME_TOKEN)
+    content = draw(
+        st.sampled_from(
+            (
+                f"[o:{key}:p]\nfile_filter = locale/<lang>.json\nsource_file = locale/en.json\ntype = KEYVALUEJSON\n",
+                "[main\nbroken\n",
+                "",
+            ),
+        ),
+    )
+    return {
+        ".tx/config": content,
+        "locale/en.json": json.dumps({"hello": "world"}),
+        "locale/cs.json": json.dumps({"hello": "svet"}),
+    }
+
+
+CONTENT_FILE_BUILDERS = (
+    android_files,
+    csv_files,
+    flat_xml_files,
+    json_files,
+    php_files,
+    properties_files,
+    toml_files,
+    transifex_files,
+    xliff_files,
+    yaml_files,
+)
+
+
+@st.composite
+def content_file_set(draw: st.DrawFn) -> FileSet:
+    """Generate real file trees whose content is inspected by discovery."""
+    builder = draw(st.sampled_from(CONTENT_FILE_BUILDERS))
+    return builder(draw)
 
 
 @st.composite
@@ -163,6 +378,27 @@ def make_dir_items(paths: Iterable[str]) -> list[tuple[PurePath, PurePath, str]]
     return make_path_items(directories)
 
 
+def write_files(root: Path, files: FileSet) -> None:
+    """Write generated file content under a temporary root."""
+    for filename, content in files.items():
+        path = root / filename
+        path.parent.mkdir(parents=True, exist_ok=True)
+        if isinstance(content, bytes):
+            path.write_bytes(content)
+        else:
+            path.write_text(content, encoding="utf-8")
+
+
+def discover_real_files(files: FileSet) -> list[DiscoveryResult]:
+    """Run discovery on generated real files, ignoring expected parser warnings."""
+    with tempfile.TemporaryDirectory() as tmpdir:
+        root = Path(tmpdir)
+        write_files(root, files)
+        with warnings.catch_warnings():
+            warnings.simplefilter("ignore")
+            return discover(root)
+
+
 class FuzzTest(TestCase):
     @FUZZ_SETTINGS
     @given(paths=PATH_NAMES)
@@ -202,6 +438,16 @@ class FuzzTest(TestCase):
             mock=(make_path_items(paths), make_dir_items(paths)),
             source_language=source_language,
         )
+
+        self.assertEqual(sorted(results), results)
+        for result in results:
+            self.assertIsInstance(result, DiscoveryResult)
+            self.assert_valid_result(result)
+
+    @FUZZ_SETTINGS
+    @given(files=content_file_set())
+    def test_discovery_accepts_generated_file_contents(self, files: FileSet) -> None:
+        results = discover_real_files(files)
 
         self.assertEqual(sorted(results), results)
         for result in results:


### PR DESCRIPTION
Generate temporary translation files with varied content for content-sensitive discovery paths.

Cover JSON, YAML, TOML, CSV, PHP, properties, XML, XLIFF, Android resources, and Transifex config.

<!--
♥ Thank you for submitting a pull request. ♥

We will review it in a timely manner, but please follow the CI checks to see
any problems it might discover.

Want to make a perfect pull request?

• Keep the pull request reasonably sized. Creating more pull requests is sometimes better.
• Describe what the pull request does and what issues it does address.
• Ensure that lint and unit tests pass.
• Add tests that prove that the fix is effective or that the new feature works.
• Describe any new features or changed behavior in the documentation.
-->
