### PR TITLE
perf: index finder candidates

### DIFF
--- a/translation_finder/discovery/base.py
+++ b/translation_finder/discovery/base.py
@@ -188,15 +188,13 @@ class BaseDiscovery:
                 basename = basename.replace(replacement_match, replacement)
         new_name = self.new_base_mask.replace("*", basename).lower()
 
-        new_regex = f"{re.escape(new_name)}|{fnmatch.translate(self.new_base_mask)}"
-
         best_result = None
 
         while "/" in path:
             path = path.rsplit("/", 1)[0]
             path_wild = path.replace("*", "")
-            for match in self.finder.filter_files(
-                new_regex,
+            for match in self.finder.filter_masks(
+                (new_name, self.new_base_mask),
                 f"{re.escape(path)}|{re.escape(path_wild)}",
             ):
                 if new_name == match.parts[-1].lower():
@@ -288,9 +286,7 @@ class BaseDiscovery:
 
     def filter_files(self) -> Generator[PurePath]:
         """Filter possible file matches."""
-        return self.finder.filter_files(
-            "|".join(fnmatch.translate(mask) for mask in self.masks_list),
-        )
+        return self.finder.filter_masks(self.masks_list)
 
     def get_masks(
         self, *, eager: bool = False, hint: str | None = None

--- a/translation_finder/discovery/files.py
+++ b/translation_finder/discovery/files.py
@@ -411,7 +411,9 @@ class AndroidDiscovery(BaseDiscovery):
         It is expected to contain duplicates.
         """
         for path in self.finder.filter_files(
-            r"(strings.*|.*strings)\.xml", ".*/values"
+            r"(strings.*|.*strings)\.xml",
+            ".*/values",
+            candidate_suffixes=(".xml",),
         ):
             # Skip Compose Multiplatform resources
             if "composeResources" in path.as_posix():
@@ -454,6 +456,7 @@ class MOKODiscovery(BaseDiscovery):
         for path in self.finder.filter_files(
             r"(strings|plurals)\.xml",
             ".*/resources/mr/base",
+            candidate_names=("strings.xml", "plurals.xml"),
         ):
             mask = list(path.parts)
             mask[-2] = "*"
@@ -491,13 +494,17 @@ class OSXDiscovery(EncodingDiscovery):
         for path in self.finder.filter_files(
             r".*\.strings",
             r".*/(base|en(-[a-z]{2})?)\.lproj",
+            candidate_suffixes=(".strings",),
         ):
             mask = list(path.parts)
             mask[-2] = "*.lproj"
 
             yield {"filemask": "/".join(mask), "template": path.as_posix()}
 
-        for path in self.finder.filter_files(r"base\.strings"):
+        for path in self.finder.filter_files(
+            r"base\.strings",
+            candidate_names=("base.strings",),
+        ):
             mask = list(path.parts)
             mask[-1] = "*.strings"
 
@@ -521,6 +528,7 @@ class StringsdictDiscovery(BaseDiscovery):
         for path in self.finder.filter_files(
             r".*\.stringsdict",
             r".*/(base|en)\.lproj",
+            candidate_suffixes=(".stringsdict",),
         ):
             mask = list(path.parts)
             mask[-2] = "*.lproj"
@@ -590,7 +598,10 @@ class RESXDiscovery(BaseDiscovery):
 
         It is expected to contain duplicates.
         """
-        for path in self.finder.filter_files(r".*\..*\.res[xw]"):
+        for path in self.finder.filter_files(
+            r".*\..*\.res[xw]",
+            candidate_suffixes=(".resx", ".resw"),
+        ):
             mask = list(path.parts)
             base, code, ext = mask[-1].rsplit(".", 2)
             if not self.is_language_code(code):
@@ -620,9 +631,20 @@ class AppStoreDiscovery(EnglishVariantsDiscovery):
         """Filter possible file matches."""
         for path in self.finder.filter_files(
             "short_description.txt|full_description.txt|title.txt|description.txt|name.txt",
+            candidate_names=(
+                "short_description.txt",
+                "full_description.txt",
+                "title.txt",
+                "description.txt",
+                "name.txt",
+            ),
         ):
             yield path.parent
-        for path in self.finder.filter_files(r".*\.txt", ".*/changelogs"):
+        for path in self.finder.filter_files(
+            r".*\.txt",
+            ".*/changelogs",
+            candidate_suffixes=(".txt",),
+        ):
             yield path.parent.parent
 
     def has_storage(self, name: str) -> bool:
@@ -1141,7 +1163,11 @@ class FormatJSDiscovery(BaseDiscovery):
 
         It is expected to contain duplicates.
         """
-        for path in self.finder.filter_files(r"en.json", ".*/extracted"):
+        for path in self.finder.filter_files(
+            r"en.json",
+            ".*/extracted",
+            candidate_names=("en.json",),
+        ):
             mask = list(path.parts)
             mask[-1] = "*.json"
             mask[-2] = "lang"
@@ -1204,7 +1230,9 @@ class CMPDiscovery(BaseDiscovery):
         It is expected to contain duplicates.
         """
         for path in self.finder.filter_files(
-            r"(strings.*|.*strings)\.xml", ".*/values"
+            r"(strings.*|.*strings)\.xml",
+            ".*/values",
+            candidate_suffixes=(".xml",),
         ):
             # Only match files in composeResources directories
             if "composeResources" not in path.as_posix():

--- a/translation_finder/discovery/transifex.py
+++ b/translation_finder/discovery/transifex.py
@@ -158,7 +158,11 @@ class TransifexDiscovery(BaseDiscovery):
         self, *, eager: bool = False, hint: str | None = None
     ) -> Generator[ResultDict]:
         """Retuns matches from transifex files."""
-        for path in self.finder.filter_files("config", "(?:.*/|^).tx"):
+        for path in self.finder.filter_files(
+            "config",
+            "(?:.*/|^).tx",
+            candidate_names=("config",),
+        ):
             config = RawConfigParser()
             with self.finder.open(path) as handle:
                 try:

--- a/translation_finder/finder.py
+++ b/translation_finder/finder.py
@@ -8,13 +8,13 @@ from __future__ import annotations
 
 import operator
 import re
-from fnmatch import fnmatch
+from fnmatch import fnmatch, translate
 from os import scandir
 from pathlib import Path, PurePath
 from typing import TYPE_CHECKING, overload
 
 if TYPE_CHECKING:
-    from collections.abc import Generator
+    from collections.abc import Generator, Iterable
     from io import FileIO, TextIOWrapper
 
     from _typeshed import OpenBinaryMode, OpenTextMode
@@ -51,6 +51,8 @@ def lc_convert(relative_path: str, relative: PurePath) -> tuple[str, str, PurePa
 PathListItem = tuple[PurePath, PurePath, str]
 PathListType = list[PathListItem]
 PathMockType = tuple[PathListType, PathListType]
+LowerPathListItem = tuple[str, str, PurePath]
+FileMatchItem = tuple[str, PurePath]
 
 
 class Finder:
@@ -79,6 +81,13 @@ class Finder:
             for absolute, relative, relative_path in files
         ]
         self.lc_files.sort(key=operator.itemgetter(slice(2)))
+        self.lc_files_by_name: dict[str, list[LowerPathListItem]] = {}
+        self.lc_files_by_suffix: dict[str, list[LowerPathListItem]] = {}
+        for lc_item in self.lc_files:
+            filename = lc_item[1]
+            self.lc_files_by_name.setdefault(filename, []).append(lc_item)
+            if suffix := self.get_suffix(filename):
+                self.lc_files_by_suffix.setdefault(suffix, []).append(lc_item)
         # Needed for open
         self.absolutes = {
             relative_path: absolute for absolute, relative, relative_path in files
@@ -88,6 +97,56 @@ class Finder:
             (relative_path, relative) for absolute, relative, relative_path in files
         ]
         self.files.sort(key=operator.itemgetter(0))
+        self.files_by_path = dict(self.files)
+        self.files_by_name: dict[str, list[FileMatchItem]] = {}
+        self.files_by_suffix: dict[str, list[FileMatchItem]] = {}
+        for file_item in self.files:
+            relative_path = file_item[0]
+            filename = relative_path.rsplit("/", 1)[-1]
+            self.files_by_name.setdefault(filename, []).append(file_item)
+            if suffix := self.get_suffix(filename.lower()):
+                self.files_by_suffix.setdefault(suffix, []).append(file_item)
+
+    @staticmethod
+    def get_suffix(filename: str) -> str | None:
+        """Return the final file suffix usable for candidate narrowing."""
+        dot_position = filename.rfind(".")
+        if dot_position == -1 or dot_position == len(filename) - 1:
+            return None
+        return filename[dot_position:]
+
+    @staticmethod
+    def has_glob_magic(pattern: str, magic: str = "*?[") -> bool:
+        """Check whether pattern contains glob wildcards."""
+        return any(char in pattern for char in magic)
+
+    @classmethod
+    def glob_suffix_candidate(cls, pattern: str, magic: str = "*?[") -> str | None:
+        """Return a safe suffix candidate for a glob pattern."""
+        last_magic = max((pattern.rfind(char) for char in magic), default=-1)
+        if last_magic == -1:
+            return cls.get_suffix(pattern.lower())
+        tail = pattern[last_magic + 1 :]
+        return cls.get_suffix(tail.lower())
+
+    @classmethod
+    def mask_candidates(
+        cls, masks: tuple[str, ...]
+    ) -> tuple[set[str], set[str]] | None:
+        """Return indexed filename candidates for fnmatch-style masks."""
+        names: set[str] = set()
+        suffixes: set[str] = set()
+        for mask in masks:
+            filename = mask.rsplit("/", 1)[-1]
+            if not cls.has_glob_magic(filename):
+                names.add(filename.lower())
+                continue
+            if suffix := cls.glob_suffix_candidate(filename):
+                suffixes.add(suffix)
+                continue
+            return None
+
+        return names, suffixes
 
     def process_path(self, path: PurePath) -> tuple[PurePath, PurePath, str]:
         """Convert path to relative path."""
@@ -129,19 +188,86 @@ class Finder:
 
     def mask_matches(self, mask: str) -> Generator[PurePath]:
         """Return all mask matches."""
+        candidates: tuple[FileMatchItem, ...] | list[FileMatchItem]
+        if "*" not in mask:
+            match = self.files_by_path.get(mask)
+            candidates = ((mask, match),) if match is not None else ()
+        else:
+            filename = mask.rsplit("/", 1)[-1]
+            if "*" not in filename:
+                candidates = self.files_by_name.get(filename, [])
+            elif suffix := self.glob_suffix_candidate(filename, magic="*"):
+                candidates = self.files_by_suffix.get(suffix, [])
+            else:
+                candidates = self.files
+
         # Avoid dealing [ as a special char
         mask = mask.replace("[", "[[]").replace("?", "[?]")
-        for name, path in self.files:
+        for name, path in candidates:
             if fnmatch(name, mask):
                 yield path
 
+    def get_lc_candidates(
+        self,
+        candidate_names: Iterable[str] | None,
+        candidate_suffixes: Iterable[str] | None,
+    ) -> list[LowerPathListItem]:
+        """Return lowercase file candidates narrowed by filename hints."""
+        if candidate_names is None and candidate_suffixes is None:
+            return self.lc_files
+
+        candidates: dict[PurePath, LowerPathListItem] = {}
+        if candidate_names is not None:
+            for name in candidate_names:
+                for item in self.lc_files_by_name.get(name.lower(), ()):
+                    candidates[item[2]] = item
+        if candidate_suffixes is not None:
+            for suffix in candidate_suffixes:
+                for item in self.lc_files_by_suffix.get(suffix.lower(), ()):
+                    candidates[item[2]] = item
+
+        result = list(candidates.values())
+        result.sort(key=operator.itemgetter(slice(2)))
+        return result
+
+    def filter_masks(
+        self,
+        masks: str | Iterable[str],
+        dirglob: str | None = None,
+    ) -> Generator[PurePath]:
+        """Filter lowercase file names against fnmatch-style masks."""
+        masks = (masks,) if isinstance(masks, str) else tuple(masks)
+        if not masks:
+            return
+
+        candidates = self.mask_candidates(masks)
+        if candidates is None:
+            candidate_names = candidate_suffixes = None
+        else:
+            candidate_names, candidate_suffixes = candidates
+
+        yield from self.filter_files(
+            "|".join(translate(mask) for mask in masks),
+            dirglob,
+            candidate_names=candidate_names,
+            candidate_suffixes=candidate_suffixes,
+        )
+
     def filter_files(
-        self, fileglob: str, dirglob: str | None = None
+        self,
+        fileglob: str,
+        dirglob: str | None = None,
+        *,
+        candidate_names: Iterable[str] | None = None,
+        candidate_suffixes: Iterable[str] | None = None,
     ) -> Generator[PurePath]:
         """Filter lowercase file names against glob."""
         fileglob_re = re.compile(fileglob)
         dirglob_re = re.compile(dirglob) if dirglob else None
-        for directory, filename, path in self.lc_files:
+        for directory, filename, path in self.get_lc_candidates(
+            candidate_names,
+            candidate_suffixes,
+        ):
             if dirglob_re and not dirglob_re.fullmatch(directory):
                 continue
 

--- a/translation_finder/test_finder.py
+++ b/translation_finder/test_finder.py
@@ -5,6 +5,7 @@
 
 import pathlib
 import tempfile
+from fnmatch import translate
 from unittest import TestCase
 from unittest.mock import patch
 
@@ -12,6 +13,23 @@ from .finder import Finder
 
 
 class FinderTest(TestCase):
+    @staticmethod
+    def get_finder(paths: list[str]) -> Finder:
+        return Finder(
+            pathlib.PurePath(),
+            mock=(
+                [
+                    (
+                        pathlib.PurePath(path),
+                        pathlib.PurePath(path),
+                        path,
+                    )
+                    for path in paths
+                ],
+                [],
+            ),
+        )
+
     def test_init(self) -> None:
         finder = Finder(pathlib.Path(__file__).parent)
         self.assertNotEqual(finder.files, {})
@@ -24,6 +42,118 @@ class FinderTest(TestCase):
         self.assertIsInstance(result[0], pathlib.Path)
         expected_path = pathlib.Path("test_finder.py")
         self.assertEqual(result[0], expected_path)
+
+    def test_filter_masks_exact_name(self) -> None:
+        finder = self.get_finder(
+            [
+                "locale/cs/messages.json",
+                "locale/en/messages.json",
+                "locale/en/other.json",
+                "locale/en/messages.po",
+            ],
+        )
+
+        self.assertEqual(
+            list(finder.filter_masks("messages.json")),
+            [
+                pathlib.PurePath("locale/cs/messages.json"),
+                pathlib.PurePath("locale/en/messages.json"),
+            ],
+        )
+
+    def test_filter_masks_suffix(self) -> None:
+        finder = self.get_finder(
+            [
+                "locale/en/messages.po",
+                "locale/cs/messages.po",
+                "locale/en/messages.json",
+            ],
+        )
+
+        self.assertEqual(
+            list(finder.filter_masks("*.po")),
+            [
+                pathlib.PurePath("locale/cs/messages.po"),
+                pathlib.PurePath("locale/en/messages.po"),
+            ],
+        )
+
+    def test_filter_masks_empty(self) -> None:
+        finder = self.get_finder(["locale/en/messages.po"])
+
+        self.assertEqual(list(finder.filter_masks(())), [])
+
+    def test_glob_suffix_candidate_without_glob_magic(self) -> None:
+        self.assertEqual(Finder.glob_suffix_candidate("messages.po"), ".po")
+
+    def test_filter_files_candidate_hints_match_full_scan(self) -> None:
+        finder = self.get_finder(
+            [
+                "locale/en/app.resx",
+                "locale/cs/app.resx",
+                "locale/de/app.resw",
+                "locale/de/app.po",
+            ],
+        )
+
+        expected = list(finder.filter_files(r".*\.res[xw]"))
+        actual = list(
+            finder.filter_files(
+                r".*\.res[xw]",
+                candidate_suffixes=(".resx", ".resw"),
+            ),
+        )
+
+        self.assertEqual(actual, expected)
+
+    def test_filter_masks_fallback_matches_filter_files(self) -> None:
+        finder = self.get_finder(
+            [
+                "locale/en/resources.resx",
+                "locale/en/resources.resw",
+                "locale/en/resources.resz",
+            ],
+        )
+
+        self.assertEqual(
+            list(finder.filter_masks("resources.res[xw]")),
+            list(finder.filter_files(translate("resources.res[xw]"))),
+        )
+
+    def test_mask_matches_uses_literal_question_and_bracket(self) -> None:
+        finder = self.get_finder(
+            [
+                "locale/en?.json",
+                "locale/en[1].json",
+                "locale/enx.json",
+            ],
+        )
+
+        self.assertEqual(
+            list(finder.mask_matches("locale/en?.json")),
+            [pathlib.PurePath("locale/en?.json")],
+        )
+        self.assertEqual(
+            list(finder.mask_matches("locale/en[1].json")),
+            [pathlib.PurePath("locale/en[1].json")],
+        )
+
+    def test_mask_matches_falls_back_for_suffixless_wildcard(self) -> None:
+        finder = self.get_finder(
+            [
+                "locale/messages",
+                "locale/messages.po",
+                "other/messages",
+            ],
+        )
+
+        self.assertEqual(
+            list(finder.mask_matches("locale/*")),
+            [
+                pathlib.PurePath("locale/messages"),
+                pathlib.PurePath("locale/messages.po"),
+            ],
+        )
 
     def test_unreadable_directories_are_skipped(self) -> None:
         class FakeEntry:


### PR DESCRIPTION
Add exact-name and suffix indexes to narrow discovery scans before applying existing match checks.

This reduces repeated full-file-list scans in large repositories while preserving discovery results.

<!--
♥ Thank you for submitting a pull request. ♥

We will review it in a timely manner, but please follow the CI checks to see
any problems it might discover.

Want to make a perfect pull request?

• Keep the pull request reasonably sized. Creating more pull requests is sometimes better.
• Describe what the pull request does and what issues it does address.
• Ensure that lint and unit tests pass.
• Add tests that prove that the fix is effective or that the new feature works.
• Describe any new features or changed behavior in the documentation.
-->
