### PR TITLE
fix: handle recursive TOML parsing failures

### DIFF
--- a/translation_finder/discovery/files.py
+++ b/translation_finder/discovery/files.py
@@ -1056,7 +1056,7 @@ class TOMLDiscovery(BaseDiscovery):
             return
         try:
             data = tomllib.loads(content)
-        except (tomllib.TOMLDecodeError, OSError) as error:
+        except (tomllib.TOMLDecodeError, OSError, RecursionError) as error:
             warnings.warn(f"Could not parse TOML: {error}", stacklevel=0)
             return
         # go-i18n-toml detection - has messages array with 'id' field

--- a/translation_finder/test_discovery.py
+++ b/translation_finder/test_discovery.py
@@ -1933,6 +1933,58 @@ class TOMLDiscoveryTest(DiscoveryTestCase):
                     ],
                 )
 
+    def test_adjust_format_recursion_error_warning(self) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            tmppath = Path(tmpdir)
+            (tmppath / "en.toml").write_text("[a]\nb = 1\n", encoding="utf-8")
+            discovery = TOMLDiscovery(Finder(tmppath))
+            result: ResultDict = {
+                "filemask": "*.toml",
+                "file_format": "toml",
+                "template": "en.toml",
+            }
+
+            with (
+                patch.object(
+                    files_module.tomllib,
+                    "loads",
+                    side_effect=RecursionError("too deep"),
+                ),
+                self.assertWarnsRegex(UserWarning, "Could not parse TOML: too deep"),
+            ):
+                discovery.adjust_format(result)
+
+        self.assertEqual(
+            result,
+            {
+                "filemask": "*.toml",
+                "file_format": "toml",
+                "template": "en.toml",
+            },
+        )
+
+    def test_deeply_nested_toml_does_not_crash_discovery(self) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            tmppath = Path(tmpdir)
+            content = "[a]\nb = " + "[" * 5000 + "]" * 5000 + "\n"
+            (tmppath / "en.toml").write_text(content, encoding="utf-8")
+            (tmppath / "cs.toml").write_text(content, encoding="utf-8")
+            discovery = TOMLDiscovery(Finder(tmppath))
+
+            with self.assertWarnsRegex(UserWarning, "Could not parse TOML"):
+                results = list(discovery.discover())
+
+        self.assert_discovery(
+            results,
+            [
+                {
+                    "filemask": "*.toml",
+                    "file_format": "toml",
+                    "template": "en.toml",
+                },
+            ],
+        )
+
 
 class ARBDiscoveryTest(DiscoveryTestCase):
     def test_basic(self) -> None:


### PR DESCRIPTION
Catch RecursionError from tomllib so crafted TOML files warn and fall back to generic discovery instead of crashing discover().

<!--
♥ Thank you for submitting a pull request. ♥

We will review it in a timely manner, but please follow the CI checks to see
any problems it might discover.

Want to make a perfect pull request?

• Keep the pull request reasonably sized. Creating more pull requests is sometimes better.
• Describe what the pull request does and what issues it does address.
• Ensure that lint and unit tests pass.
• Add tests that prove that the fix is effective or that the new feature works.
• Describe any new features or changed behavior in the documentation.
-->
