### PR TITLE
fix: avoid quadratic new-base discovery

### DIFF
--- a/translation_finder/discovery/base.py
+++ b/translation_finder/discovery/base.py
@@ -104,6 +104,10 @@ class BaseDiscovery:
     def __init__(self, finder: Finder, source_language: str = "en") -> None:
         self.finder: Finder = finder
         self.source_language: str = source_language
+        self._new_base_by_directory: dict[str, tuple[int, PurePath]] | None = None
+        self._new_base_by_name: dict[tuple[str, str], tuple[int, PurePath]] | None = (
+            None
+        )
 
     @staticmethod
     def is_country_code(code: str) -> bool:
@@ -189,22 +193,58 @@ class BaseDiscovery:
         new_name = self.new_base_mask.replace("*", basename).lower()
 
         best_result = None
+        new_base_by_directory, new_base_by_name = self._index_new_bases()
 
         while "/" in path:
             path = path.rsplit("/", 1)[0]
             path_wild = path.replace("*", "")
-            for match in self.finder.filter_masks(
-                (new_name, self.new_base_mask),
-                f"{re.escape(path)}|{re.escape(path_wild)}",
-            ):
-                if new_name == match.parts[-1].lower():
-                    result["new_base"] = "/".join(match.parts)
-                    return
-                if not best_result:
-                    best_result = "/".join(match.parts)
+            directories = {path, path_wild}
+            exact_matches = (
+                new_base_by_name[directory, new_name]
+                for directory in directories
+                if (directory, new_name) in new_base_by_name
+            )
+            exact_match = min(exact_matches, default=None)
+            if exact_match is not None:
+                result["new_base"] = "/".join(exact_match[1].parts)
+                return
+
+            if best_result is None:
+                fallback_matches = (
+                    new_base_by_directory[directory]
+                    for directory in directories
+                    if directory in new_base_by_directory
+                )
+                fallback_match = min(fallback_matches, default=None)
+                if fallback_match is not None:
+                    best_result = "/".join(fallback_match[1].parts)
 
         if best_result is not None:
             result["new_base"] = best_result
+
+    def _index_new_bases(
+        self,
+    ) -> tuple[
+        dict[str, tuple[int, PurePath]],
+        dict[tuple[str, str], tuple[int, PurePath]],
+    ]:
+        """Index possible new-base files for repeated constant-time lookups."""
+        if self._new_base_by_directory is None or self._new_base_by_name is None:
+            self._new_base_by_directory = {}
+            self._new_base_by_name = {}
+            if self.new_base_mask is not None:
+                for position, match in enumerate(
+                    self.finder.filter_masks(self.new_base_mask)
+                ):
+                    directory = "/".join(match.parts[:-1]).lower()
+                    candidate = (position, match)
+                    self._new_base_by_directory.setdefault(directory, candidate)
+                    self._new_base_by_name.setdefault(
+                        (directory, match.parts[-1].lower()),
+                        candidate,
+                    )
+
+        return self._new_base_by_directory, self._new_base_by_name
 
     def has_storage(self, name: str) -> bool:
         """Check whether finder has a storage."""

--- a/translation_finder/test_discovery.py
+++ b/translation_finder/test_discovery.py
@@ -620,6 +620,44 @@ class QtTest(DiscoveryTestCase):
             ],
         )
 
+    def test_exact_new_base_precedes_nearer_fallback(self) -> None:
+        discovery = QtDiscovery(
+            self.get_finder(
+                [
+                    "parent/child/app_fr.ts",
+                    "parent/child/fallback.ts",
+                    "parent/app_.ts",
+                ],
+            ),
+        )
+        self.assert_discovery(
+            discovery.discover(),
+            [
+                {
+                    "filemask": "parent/child/app_*.ts",
+                    "file_format": "ts",
+                    "new_base": "parent/app_.ts",
+                },
+            ],
+        )
+
+    def test_new_base_candidates_are_indexed_once(self) -> None:
+        finder = self.get_finder(
+            [f"d0/d1/d2/d3/comp{i}/en.ts" for i in range(1000)],
+        )
+        discovery = QtDiscovery(finder)
+
+        with patch.object(
+            finder, "filter_masks", wraps=finder.filter_masks
+        ) as filter_masks:
+            results = list(discovery.discover())
+
+        self.assertEqual(len(results), 1000)
+        self.assertEqual(
+            sum(call.args == ("*.ts",) for call in filter_masks.call_args_list),
+            1,
+        )
+
     def test_po_mono_template(self) -> None:
         discovery = GettextDiscovery(
             self.get_finder(


### PR DESCRIPTION
Index new-base candidates once so Qt repositories with many .ts files do not repeatedly rescan the same suffix bucket and consume excessive discovery worker CPU.

<!--
♥ Thank you for submitting a pull request. ♥

We will review it in a timely manner, but please follow the CI checks to see
any problems it might discover.

Want to make a perfect pull request?

• Keep the pull request reasonably sized. Creating more pull requests is sometimes better.
• Describe what the pull request does and what issues it does address.
• Ensure that lint and unit tests pass.
• Add tests that prove that the fix is effective or that the new feature works.
• Describe any new features or changed behavior in the documentation.
-->
