### PR TITLE
feat: detect Qt TS version from content

### DIFF
--- a/translation_finder/discovery/files.py
+++ b/translation_finder/discovery/files.py
@@ -37,6 +37,24 @@ if TYPE_CHECKING:
 LARAVEL_RE = re.compile(r"=>.*\|")
 LARAVEL_BYTES_RE = re.compile(rb"=>.*\|")
 GWT_PLURAL_RE = re.compile(r"^[^#!\s][^:=\n]*\[[a-zA-Z_]+\]\s*[:=]", re.MULTILINE)
+QT_TS_ROOT_RE = re.compile(
+    r"""
+    \A \ufeff? \s*
+    (?: (?: <\?.*?\?> | <!-- .*? --> ) \s*)*
+    (?: <!DOCTYPE\s+TS (?:\s[^>]*)? > \s*)?
+    (?: (?: <\?.*?\?> | <!-- .*? --> ) \s*)*
+    <TS\b
+    (?P<attributes>
+        (?: \s+ [^\s=/>]+ \s*=\s* (?: "[^"]*" | '[^']*' ) )*
+    )
+    \s*/?>
+    """,
+    re.DOTALL | re.VERBOSE,
+)
+QT_TS_ATTRIBUTE_RE = re.compile(
+    r"""\s+([^\s=/>]+)\s*=\s*(?:"([^"]*)"|'([^']*)')""",
+    re.DOTALL,
+)
 FORMAT_SNIFF_MAX_BYTES = 1024 * 1024
 CSV_SAMPLE_ROWS = 100
 SIMPLE_CSV_COLUMNS = 2
@@ -56,6 +74,17 @@ CSV_FIELDNAMES = {
 }
 
 
+def _detect_utf32_encoding(content: bytes) -> str | None:
+    """Detect standard UTF-32 byte orders from a BOM or XML opening marker."""
+    if content.startswith((b"\x00\x00\xfe\xff", b"\xff\xfe\x00\x00")):
+        return "utf-32"
+    if content.startswith(b"\x00\x00\x00<"):
+        return "utf-32-be"
+    if content.startswith(b"<\x00\x00\x00"):
+        return "utf-32-le"
+    return None
+
+
 def _decode_content(content: bytes) -> str:
     """Decode sampled file content."""
     for encoding in ("utf-8-sig", "utf-16"):
@@ -68,6 +97,11 @@ def _decode_content(content: bytes) -> str:
 
 def _decode_sample_content(content: bytes) -> str:
     """Decode sampled file content, ignoring incomplete trailing bytes."""
+    if encoding := _detect_utf32_encoding(content):
+        return content[: len(content) - len(content) % 4].decode(
+            encoding, errors="replace"
+        )
+
     try:
         return content.decode("utf-8-sig")
     except UnicodeDecodeError as error:
@@ -313,6 +347,30 @@ class QtDiscovery(BaseDiscovery):
     file_format = "ts"
     mask = "*.ts"
     new_base_mask = "*.ts"
+
+    def adjust_format(self, result: ResultDict) -> None:
+        """Detect legacy Qt Linguist files based on the TS root version."""
+        path = next(iter(self.finder.mask_matches(result["filemask"])), None)
+        if path is None:
+            return
+
+        content = _read_text_sample(self.finder, path)
+        if content is None:
+            return
+
+        root_match = QT_TS_ROOT_RE.search(content)
+        if root_match is None:
+            return
+
+        for attribute_match in QT_TS_ATTRIBUTE_RE.finditer(
+            root_match.group("attributes")
+        ):
+            name, double_quoted, single_quoted = attribute_match.groups()
+            if name == "version":
+                version = double_quoted if double_quoted is not None else single_quoted
+                if version.startswith("1."):
+                    result["file_format"] = "ts1"
+                return
 
 
 @register_discovery

--- a/translation_finder/test_discovery.py
+++ b/translation_finder/test_discovery.py
@@ -658,6 +658,91 @@ class QtTest(DiscoveryTestCase):
             1,
         )
 
+    def test_detects_ts_version(self) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            tmppath = Path(tmpdir)
+            (tmppath / "ts1").mkdir()
+            (tmppath / "ts2").mkdir()
+            (tmppath / "ts1/cs.ts").write_text(
+                """<?build metadata?>
+<!DOCTYPE TS>
+<TS language="cs" version = '1.1'></TS>
+""",
+                encoding="utf-8",
+            )
+            (tmppath / "ts2/cs.ts").write_text(
+                """<?xml version="1.0" encoding="utf-8"?>
+<!DOCTYPE TS>
+<!-- <TS version="1.1"></TS> -->
+<TS xmlns:x="urn:version='1.1'" version="2.1" language="cs"></TS>
+""",
+                encoding="utf-8",
+            )
+
+            results = QtDiscovery(Finder(tmppath)).discover()
+
+            self.assert_discovery(
+                results,
+                [
+                    {
+                        "filemask": "ts1/*.ts",
+                        "file_format": "ts1",
+                        "new_base": "ts1/cs.ts",
+                    },
+                    {
+                        "filemask": "ts2/*.ts",
+                        "file_format": "ts",
+                        "new_base": "ts2/cs.ts",
+                    },
+                ],
+            )
+
+    def test_detects_multibyte_ts_version_1(self) -> None:
+        for encoding in ("utf-16", "utf-32"):
+            with (
+                self.subTest(encoding=encoding),
+                tempfile.TemporaryDirectory() as tmpdir,
+            ):
+                tmppath = Path(tmpdir)
+                (tmppath / "cs.ts").write_text(
+                    f"""<?xml version="1.0" encoding="{encoding}"?>
+<TS version="1.0"></TS>
+""",
+                    encoding=encoding,
+                )
+
+                self.assert_discovery(
+                    QtDiscovery(Finder(tmppath)).discover(),
+                    [
+                        {
+                            "filemask": "*.ts",
+                            "file_format": "ts1",
+                        },
+                    ],
+                )
+
+    def test_unrecognized_content_defaults_to_version_2(self) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            tmppath = Path(tmpdir)
+            (tmppath / "cs.ts").write_text("not XML", encoding="utf-8")
+
+            self.assert_discovery(
+                QtDiscovery(Finder(tmppath)).discover(),
+                [
+                    {
+                        "filemask": "*.ts",
+                        "file_format": "ts",
+                    },
+                ],
+            )
+
+    def test_missing_file_defaults_to_version_2(self) -> None:
+        result: ResultDict = {"filemask": "missing.ts"}
+
+        QtDiscovery(self.get_finder([])).adjust_format(result)
+
+        self.assertEqual(result, {"filemask": "missing.ts"})
+
     def test_po_mono_template(self) -> None:
         discovery = GettextDiscovery(
             self.get_finder(
@@ -2352,6 +2437,12 @@ class FormatSniffLimitTest(DiscoveryTestCase):
             files_module._decode_sample_content(b"\xff\xfeA\x00B"),
             "A",
         )
+        for encoding in ("utf-32-le", "utf-32-be"):
+            with self.subTest(encoding=encoding):
+                self.assertEqual(
+                    files_module._decode_sample_content("<TS>".encode(encoding)),
+                    "<TS>",
+                )
 
     def test_text_sample_ignores_truncated_utf8_character(self) -> None:
         with tempfile.TemporaryDirectory() as tmpdir:


### PR DESCRIPTION
Weblate now distinguishes legacy Qt TS 1 catalogs from TS 2. Inspect the root version so discovery selects the matching backend automatically.

<!--
♥ Thank you for submitting a pull request. ♥

We will review it in a timely manner, but please follow the CI checks to see
any problems it might discover.

Want to make a perfect pull request?

• Keep the pull request reasonably sized. Creating more pull requests is sometimes better.
• Describe what the pull request does and what issues it does address.
• Ensure that lint and unit tests pass.
• Add tests that prove that the fix is effective or that the new feature works.
• Describe any new features or changed behavior in the documentation.
-->
