### PR TITLE
fix: prevent regex denial of service

### DIFF
--- a/translation_finder/discovery/files.py
+++ b/translation_finder/discovery/files.py
@@ -13,6 +13,7 @@ import tomllib
 import warnings
 from io import StringIO
 from typing import TYPE_CHECKING, ClassVar, cast
+from xml.parsers import expat
 
 from ruamel.yaml import YAML
 from ruamel.yaml.error import YAMLError, YAMLFutureWarning
@@ -37,24 +38,6 @@ if TYPE_CHECKING:
 LARAVEL_RE = re.compile(r"=>.*\|")
 LARAVEL_BYTES_RE = re.compile(rb"=>.*\|")
 GWT_PLURAL_RE = re.compile(r"^[^#!\s][^:=\n]*\[[a-zA-Z_]+\]\s*[:=]", re.MULTILINE)
-QT_TS_ROOT_RE = re.compile(
-    r"""
-    \A \ufeff? \s*
-    (?: (?: <\?.*?\?> | <!-- .*? --> ) \s*)*
-    (?: <!DOCTYPE\s+TS (?:\s[^>]*)? > \s*)?
-    (?: (?: <\?.*?\?> | <!-- .*? --> ) \s*)*
-    <TS\b
-    (?P<attributes>
-        (?: \s+ [^\s=/>]+ \s*=\s* (?: "[^"]*" | '[^']*' ) )*
-    )
-    \s*/?>
-    """,
-    re.DOTALL | re.VERBOSE,
-)
-QT_TS_ATTRIBUTE_RE = re.compile(
-    r"""\s+([^\s=/>]+)\s*=\s*(?:"([^"]*)"|'([^']*)')""",
-    re.DOTALL,
-)
 FORMAT_SNIFF_MAX_BYTES = 1024 * 1024
 CSV_SAMPLE_ROWS = 100
 SIMPLE_CSV_COLUMNS = 2
@@ -72,6 +55,31 @@ CSV_FIELDNAMES = {
     "target_plural_form",
     "translator_comments",
 }
+
+
+class _QtRootFoundError(Exception):
+    """Stop Qt XML parsing after the root element."""
+
+
+def _get_qt_ts_version(content: str) -> str | None:
+    """Return the version from a Qt TS root element."""
+    version: str | None = None
+    parser = expat.ParserCreate()
+
+    def handle_start(name: str, attributes: dict[str, str]) -> None:
+        nonlocal version
+        if name == "TS":
+            version = attributes.get("version")
+        raise _QtRootFoundError
+
+    parser.StartElementHandler = handle_start
+    try:
+        parser.Parse(content, False)  # ruff: ignore[boolean-positional-value-in-call]
+    except _QtRootFoundError:
+        return version
+    except expat.ExpatError:
+        return None
+    return None
 
 
 def _detect_utf32_encoding(content: bytes) -> str | None:
@@ -358,19 +366,9 @@ class QtDiscovery(BaseDiscovery):
         if content is None:
             return
 
-        root_match = QT_TS_ROOT_RE.search(content)
-        if root_match is None:
-            return
-
-        for attribute_match in QT_TS_ATTRIBUTE_RE.finditer(
-            root_match.group("attributes")
-        ):
-            name, double_quoted, single_quoted = attribute_match.groups()
-            if name == "version":
-                version = double_quoted if double_quoted is not None else single_quoted
-                if version.startswith("1."):
-                    result["file_format"] = "ts1"
-                return
+        version = _get_qt_ts_version(content)
+        if version is not None and version.startswith("1."):
+            result["file_format"] = "ts1"
 
 
 @register_discovery

--- a/translation_finder/discovery/transifex.py
+++ b/translation_finder/discovery/transifex.py
@@ -86,7 +86,7 @@ class TransifexDiscovery(BaseDiscovery):
         filemask = self.normalize_config_path(
             config.get(section, "file_filter").replace("<lang>", "*")
         )
-        if not self.is_safe_config_path(filemask):
+        if filemask.count("*") != 1 or not self.is_safe_config_path(filemask):
             return None
         result: ResultDict = {
             "name": section,
@@ -121,11 +121,18 @@ class TransifexDiscovery(BaseDiscovery):
     @staticmethod
     def get_language_regex(filemask: str, source_file: str) -> str | None:
         """Return filter excluding the source language matched by the file mask."""
-        pattern = re.escape(filemask).replace(r"\*", r"([^/]+)")
-        match = re.fullmatch(pattern, source_file)
-        if match is None:
+        if filemask.count("*") != 1:
             return None
-        return rf"^(?!{re.escape(match.group(1))}$).+$"
+
+        prefix, suffix = filemask.split("*")
+        if not source_file.startswith(prefix) or not source_file.endswith(suffix):
+            return None
+
+        language_end = len(source_file) - len(suffix) if suffix else len(source_file)
+        language = source_file[len(prefix) : language_end]
+        if not language or "/" in language:
+            return None
+        return rf"^(?!{re.escape(language)}$).+$"
 
     def discover(
         self, *, eager: bool = False, hint: str | None = None

--- a/translation_finder/test_discovery.py
+++ b/translation_finder/test_discovery.py
@@ -736,6 +736,24 @@ class QtTest(DiscoveryTestCase):
                 ],
             )
 
+    def test_malformed_prolog_defaults_to_version_2(self) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            tmppath = Path(tmpdir)
+            (tmppath / "cs.ts").write_text(
+                "<?build metadata?>" * 1000 + "not XML",
+                encoding="utf-8",
+            )
+
+            self.assert_discovery(
+                QtDiscovery(Finder(tmppath)).discover(),
+                [
+                    {
+                        "filemask": "*.ts",
+                        "file_format": "ts",
+                    },
+                ],
+            )
+
     def test_missing_file_defaults_to_version_2(self) -> None:
         result: ResultDict = {"filemask": "missing.ts"}
 
@@ -1804,6 +1822,39 @@ type = PO
             ),
             "^(?!en_GB$).+$",
         )
+
+    def test_language_regex_rejects_invalid_masks_and_sources(self) -> None:
+        checks = (
+            ("locales/messages.po", "locales/en.po"),
+            ("locales/**.po", "locales/en.po"),
+            ("locales/*.po", "locale/en.po"),
+            ("locales/*.po", "locales/.po"),
+            ("locales/*", "locales/en/messages.po"),
+        )
+        for filemask, source_file in checks:
+            with self.subTest(filemask=filemask, source_file=source_file):
+                self.assertIsNone(
+                    TransifexDiscovery.get_language_regex(filemask, source_file)
+                )
+
+    def test_reject_file_filter_without_exactly_one_wildcard(self) -> None:
+        discovery = TransifexDiscovery(self.get_finder([]))
+        for file_filter in (
+            "locales/messages.po",
+            "locales/<lang>*.po",
+            "locales/<lang>/<lang>.po",
+            "locales/" + "*" * 100 + ".po",
+        ):
+            with self.subTest(file_filter=file_filter):
+                config = RawConfigParser()
+                config.read_string(
+                    f"""
+[invalid]
+file_filter = {file_filter}
+type = PO
+"""
+                )
+                self.assertIsNone(discovery.extract_section(config, "invalid"))
 
 
 class AppStoreDiscoveryTest(DiscoveryTestCase):


### PR DESCRIPTION
Repository-controlled Qt content and Transifex masks could trigger catastrophic regex backtracking. Use bounded XML parsing and deterministic wildcard extraction instead.

<!--
♥ Thank you for submitting a pull request. ♥

We will review it in a timely manner, but please follow the CI checks to see
any problems it might discover.

Want to make a perfect pull request?

• Keep the pull request reasonably sized. Creating more pull requests is sometimes better.
• Describe what the pull request does and what issues it does address.
• Ensure that lint and unit tests pass.
• Add tests that prove that the fix is effective or that the new feature works.
• Describe any new features or changed behavior in the documentation.
-->
