### PR TITLE
fix: handle malformed discovery files

### DIFF
--- a/translation_finder/discovery/files.py
+++ b/translation_finder/discovery/files.py
@@ -883,7 +883,12 @@ class JSONDiscovery(BaseDiscovery):
         except (RecursionError, UnicodeError, ValueError) as error:
             warnings.warn(f"Could not parse JSON: {error}", stacklevel=0)
             return
-        if isinstance(data, list) and len(data) > 0 and "id" in data[0]:
+        if (
+            isinstance(data, list)
+            and len(data) > 0
+            and isinstance(data[0], dict)
+            and "id" in data[0]
+        ):
             result["file_format"] = "go-i18n-json"
             return
         if not isinstance(data, dict):

--- a/translation_finder/discovery/transifex.py
+++ b/translation_finder/discovery/transifex.py
@@ -21,6 +21,8 @@ if TYPE_CHECKING:
 
     from .result import DiscoveryResult, FileFormatParams, ResultDict
 
+TRANSIFEX_CONFIG_MAX_BYTES = 1024 * 1024
+
 
 @register_discovery
 class TransifexDiscovery(BaseDiscovery):
@@ -163,13 +165,24 @@ class TransifexDiscovery(BaseDiscovery):
             "(?:.*/|^).tx",
             candidate_names=("config",),
         ):
+            try:
+                with self.finder.open(path, "rb") as handle:
+                    content = handle.read(TRANSIFEX_CONFIG_MAX_BYTES + 1)
+            except OSError:
+                continue
+            if len(content) > TRANSIFEX_CONFIG_MAX_BYTES:
+                continue
+            try:
+                config_content = content.decode("utf-8-sig")
+            except UnicodeDecodeError:
+                continue
+
             config = RawConfigParser()
-            with self.finder.open(path) as handle:
-                try:
-                    config.read_file(handle)
-                except ConfigParserError:
-                    # Skip invalid files
-                    continue
+            try:
+                config.read_string(config_content, source=path.as_posix())
+            except ConfigParserError:
+                # Skip invalid files
+                continue
             for section in config.sections():
                 result = self.extract_section(config, section)
                 if result:

--- a/translation_finder/test_discovery.py
+++ b/translation_finder/test_discovery.py
@@ -18,6 +18,7 @@ from unittest.mock import patch
 
 from .discovery import base as base_module
 from .discovery import files as files_module
+from .discovery import transifex as transifex_module
 from .discovery.base import DiscoveryResult
 from .discovery.files import (
     YAML_INSPECTION_MAX_DEPTH,
@@ -1572,22 +1573,23 @@ class JSONDiscoveryTest(DiscoveryTestCase):
             self.assert_discovery(discovery.discover(), [])
 
     def test_list_without_id_keeps_nested_format(self) -> None:
-        with tempfile.TemporaryDirectory() as tmpdir:
-            tmppath = Path(tmpdir)
-            (tmppath / "en.json").write_text(json.dumps(["Hello"]))
-            (tmppath / "cs.json").write_text(json.dumps(["Ahoj"]))
+        for value in ("Hello", 1, None):
+            with self.subTest(value=value), tempfile.TemporaryDirectory() as tmpdir:
+                tmppath = Path(tmpdir)
+                (tmppath / "en.json").write_text(json.dumps([value]))
+                (tmppath / "cs.json").write_text(json.dumps([value]))
 
-            discovery = JSONDiscovery(Finder(tmppath))
-            self.assert_discovery(
-                discovery.discover(),
-                [
-                    {
-                        "filemask": "*.json",
-                        "file_format": "json-nested",
-                        "template": "en.json",
-                    },
-                ],
-            )
+                discovery = JSONDiscovery(Finder(tmppath))
+                self.assert_discovery(
+                    discovery.discover(),
+                    [
+                        {
+                            "filemask": "*.json",
+                            "file_format": "json-nested",
+                            "template": "en.json",
+                        },
+                    ],
+                )
 
 
 class TransifexTest(DiscoveryTestCase):
@@ -1647,6 +1649,45 @@ class TransifexTest(DiscoveryTestCase):
                 },
             ],
         )
+
+    def test_invalid_utf8_config(self) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            root = Path(tmpdir)
+            (root / ".tx").mkdir()
+            (root / ".tx" / "config").write_bytes(b"\xff")
+
+            discovery = TransifexDiscovery(Finder(root))
+
+            self.assert_discovery(discovery.discover(), [])
+
+    def test_oversized_config(self) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            root = Path(tmpdir)
+            (root / ".tx").mkdir()
+            (root / ".tx" / "config").write_text(
+                """
+[translation]
+file_filter = locales/<lang>.po
+source_file = locales/messages.pot
+type = PO
+""",
+                encoding="utf-8",
+            )
+
+            discovery = TransifexDiscovery(Finder(root))
+
+            with patch.object(transifex_module, "TRANSIFEX_CONFIG_MAX_BYTES", 4):
+                self.assert_discovery(discovery.discover(), [])
+
+    def test_config_io_error(self) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            root = Path(tmpdir)
+            (root / ".tx").mkdir()
+            (root / ".tx" / "config").touch()
+            discovery = TransifexDiscovery(Finder(root))
+
+            with patch.object(discovery.finder, "open", side_effect=OSError):
+                self.assert_discovery(discovery.discover(), [])
 
     def test_unicode_properties(self) -> None:
         config = RawConfigParser()


### PR DESCRIPTION
Avoid aborting discovery when JSON list entries are scalars or Transifex configs are unreadable, invalid UTF-8, or oversized.

<!--
♥ Thank you for submitting a pull request. ♥

We will review it in a timely manner, but please follow the CI checks to see
any problems it might discover.

Want to make a perfect pull request?

• Keep the pull request reasonably sized. Creating more pull requests is sometimes better.
• Describe what the pull request does and what issues it does address.
• Ensure that lint and unit tests pass.
• Add tests that prove that the fix is effective or that the new feature works.
• Describe any new features or changed behavior in the documentation.
-->
