### PR TITLE
fix: bound Laravel plural detection regex

### DIFF
--- a/translation_finder/discovery/files.py
+++ b/translation_finder/discovery/files.py
@@ -35,8 +35,12 @@ if TYPE_CHECKING:
 
     from .result import DiscoveryResult, ResultDict
 
-LARAVEL_RE = re.compile(r"=>.*\|")
-LARAVEL_BYTES_RE = re.compile(rb"=>.*\|")
+# Anchoring limits matching to one attempt per line, while the atomic group
+# prevents retrying the match from every subsequent ``=>`` on that line.
+LARAVEL_BYTES_RE = re.compile(
+    rb"^(?>[^\n]*?=>)[^\n]*\|",
+    re.MULTILINE,
+)
 GWT_PLURAL_RE = re.compile(r"^[^#!\s][^:=\n]*\[[a-zA-Z_]+\]\s*[:=]", re.MULTILINE)
 FORMAT_SNIFF_MAX_BYTES = 1024 * 1024
 CSV_SAMPLE_ROWS = 100

--- a/translation_finder/test_discovery.py
+++ b/translation_finder/test_discovery.py
@@ -12,6 +12,7 @@ import tempfile
 from configparser import RawConfigParser
 from operator import itemgetter
 from pathlib import Path, PurePath
+from time import monotonic
 from typing import TYPE_CHECKING, cast
 from unittest import TestCase
 from unittest.mock import patch
@@ -2789,6 +2790,31 @@ class PHPDiscoveryTest(DiscoveryTestCase):
         result: ResultDict = {"filemask": "test/*.php"}
         discovery.adjust_format(result)
         self.assertEqual(result, {"filemask": "test/*.php"})
+
+    def test_laravel_plural_detection(self) -> None:
+        tests = (
+            (b"'apples' => 'one|many'", True),
+            (b"'key|context' => 'value'", False),
+            (b"'key' => 'value'\n'one|many'", False),
+            (b"'key' =>\n'one|many'", False),
+        )
+
+        for content, expected in tests:
+            with self.subTest(content=content):
+                self.assertEqual(
+                    files_module.LARAVEL_BYTES_RE.search(content) is not None,
+                    expected,
+                )
+
+    def test_laravel_plural_detection_runtime(self) -> None:
+        content = b"return [" + b"=>" * 64_000
+
+        start = monotonic()
+        match = files_module.LARAVEL_BYTES_RE.search(content)
+        duration = monotonic() - start
+
+        self.assertIsNone(match)
+        self.assertLess(duration, 0.1)
 
 
 class RCDiscoveryTest(DiscoveryTestCase):


### PR DESCRIPTION
Anchor matching to each line and atomically commit to the first mapping operator so malicious PHP files cannot trigger quadratic backtracking.

<!--
♥ Thank you for submitting a pull request. ♥

We will review it in a timely manner, but please follow the CI checks to see
any problems it might discover.

Want to make a perfect pull request?

• Keep the pull request reasonably sized. Creating more pull requests is sometimes better.
• Describe what the pull request does and what issues it does address.
• Ensure that lint and unit tests pass.
• Add tests that prove that the fix is effective or that the new feature works.
• Describe any new features or changed behavior in the documentation.
-->
