### PR TITLE
feat: add MDX format detection

### DIFF
--- a/translation_finder/discovery/base.py
+++ b/translation_finder/discovery/base.py
@@ -71,6 +71,7 @@ EXTENSION_MAP = (
     (".tbx", "tbx"),
     (".md", "markdown"),
     (".markdown", "markdown"),
+    (".mdx", "mdx"),
     (".dw", "dokuwiki"),
     (".mw", "mediawiki"),
     (".ad", "asciidoc"),

--- a/translation_finder/discovery/files.py
+++ b/translation_finder/discovery/files.py
@@ -1183,6 +1183,14 @@ class MarkdownDiscovery(MonoTemplateDiscovery):
 
 
 @register_discovery
+class MDXDiscovery(MonoTemplateDiscovery):
+    """MDX files discovery."""
+
+    file_format = "mdx"
+    mask = "*.mdx"
+
+
+@register_discovery
 class DokuWikiDiscovery(MonoTemplateDiscovery):
     """DokuWiki text files discovery."""
 

--- a/translation_finder/test_discovery.py
+++ b/translation_finder/test_discovery.py
@@ -41,6 +41,7 @@ from .discovery.files import (
     JavaDiscovery,
     JoomlaDiscovery,
     JSONDiscovery,
+    MDXDiscovery,
     MediaWikiDiscovery,
     Mi18nDiscovery,
     MOKODiscovery,
@@ -1731,6 +1732,26 @@ type = UNICODEPROPERTIES
             },
         )
 
+    def test_mdx_extension_fallback(self) -> None:
+        config = RawConfigParser()
+        config.read_string(
+            """
+[mdx]
+file_filter = docs/<lang>.mdx
+source_file = docs/en.mdx
+"""
+        )
+        discovery = TransifexDiscovery(self.get_finder([]))
+        self.assertEqual(
+            discovery.extract_section(config, "mdx"),
+            {
+                "name": "mdx",
+                "filemask": "docs/*.mdx",
+                "file_format": "mdx",
+                "template": "docs/en.mdx",
+            },
+        )
+
     def test_section_without_source_file(self) -> None:
         config = RawConfigParser()
         config.read_string(
@@ -2939,6 +2960,20 @@ class ConvertedDocumentDiscoveryTest(DiscoveryTestCase):
                     "file_format": "xlsx",
                     "template": "csv/en.xlsx",
                     "new_base": "csv/en.xlsx",
+                },
+            ],
+        )
+
+    def test_mdx(self) -> None:
+        discovery = MDXDiscovery(self.get_finder(["docs/en.mdx", "docs/cs.mdx"]))
+        self.assert_discovery(
+            discovery.discover(),
+            [
+                {
+                    "filemask": "docs/*.mdx",
+                    "file_format": "mdx",
+                    "template": "docs/en.mdx",
+                    "new_base": "docs/en.mdx",
                 },
             ],
         )


### PR DESCRIPTION
Weblate supports MDX by default, but translation-finder could not discover MDX files or infer the format from Transifex file masks.

<!--
♥ Thank you for submitting a pull request. ♥

We will review it in a timely manner, but please follow the CI checks to see
any problems it might discover.

Want to make a perfect pull request?

• Keep the pull request reasonably sized. Creating more pull requests is sometimes better.
• Describe what the pull request does and what issues it does address.
• Ensure that lint and unit tests pass.
• Add tests that prove that the fix is effective or that the new feature works.
• Describe any new features or changed behavior in the documentation.
-->
