### PR TITLE
Fix eager appstore discovery crash

### DIFF
--- a/translation_finder/discovery/base.py
+++ b/translation_finder/discovery/base.py
@@ -344,7 +344,10 @@ class BaseDiscovery:
         for path in self.filter_files():
             parts = list(path.parts)
             if eager:
-                parts[-1] = "*.{}".format(parts[-1].rsplit(".", 1)[1])
+                filename = parts[-1]
+                if "." not in filename:
+                    continue
+                parts[-1] = "*.{}".format(filename.rsplit(".", 1)[1])
                 result: ResultDict = {"filemask": "/".join(parts)}
                 if self.uses_template:
                     result["new_base"] = result["template"] = "/".join(path.parts)

--- a/translation_finder/discovery/files.py
+++ b/translation_finder/discovery/files.py
@@ -707,6 +707,17 @@ class AppStoreDiscovery(EnglishVariantsDiscovery):
         ):
             yield path.parent.parent
 
+    def get_masks(
+        self, *, eager: bool = False, hint: str | None = None
+    ) -> Generator[ResultDict]:
+        """
+        Return all file masks found in the directory.
+
+        App store metadata is represented by language directories, so eager
+        discovery should keep the regular directory mask behavior.
+        """
+        yield from super().get_masks(eager=False, hint=hint)
+
     def has_storage(self, name: str) -> bool:
         """Check whether finder has a storage."""
         return self.finder.has_dir(name)

--- a/translation_finder/test_discovery.py
+++ b/translation_finder/test_discovery.py
@@ -20,7 +20,7 @@ from unittest.mock import patch
 from .discovery import base as base_module
 from .discovery import files as files_module
 from .discovery import transifex as transifex_module
-from .discovery.base import DiscoveryResult
+from .discovery.base import BaseDiscovery, DiscoveryResult
 from .discovery.files import (
     YAML_INSPECTION_MAX_DEPTH,
     AndroidDiscovery,
@@ -64,7 +64,7 @@ from .discovery.transifex import TransifexDiscovery
 from .finder import Finder
 
 if TYPE_CHECKING:
-    from collections.abc import Iterable
+    from collections.abc import Generator, Iterable
 
     from .discovery.base import ResultDict
 
@@ -120,6 +120,16 @@ class DiscoveryBaseTest(DiscoveryTestCase):
             discovery.discover(eager=True),
             [{"filemask": "locale/*.json", "file_format": "json-nested"}],
         )
+
+    def test_eager_discovery_skips_suffixless_paths(self) -> None:
+        class DirectoryDiscovery(BaseDiscovery):
+            file_format = "txt"
+
+            def filter_files(self) -> Generator[PurePath]:  # ruff:ignore[no-self-use]
+                yield PurePath("locale/en-US")
+
+        discovery = DirectoryDiscovery(self.get_finder([]))
+        self.assert_discovery(discovery.discover(eager=True), [])
 
     def test_encoding_discovery_without_template_or_new_params(self) -> None:
         class DetectionResult:
@@ -1945,6 +1955,24 @@ class AppStoreDiscoveryTest(DiscoveryTestCase):
                     "filemask": "private/metadata/*",
                     "file_format": "appstore",
                     "template": "private/metadata/en-AU",
+                },
+            ],
+        )
+
+    def test_eager(self) -> None:
+        discovery = AppStoreDiscovery(
+            self.get_finder(
+                ["fastlane/metadata/en-US/short_description.txt"],
+                ["fastlane/metadata/en-US"],
+            ),
+        )
+        self.assert_discovery(
+            discovery.discover(eager=True),
+            [
+                {
+                    "filemask": "fastlane/metadata/*",
+                    "file_format": "appstore",
+                    "template": "fastlane/metadata/en-US",
                 },
             ],
         )


### PR DESCRIPTION
Fastlane/App Store metadata discovery yields language directories, which made eager mask generation assume a missing filename extension and raise IndexError. Skip suffixless eager paths generically and keep App Store directory masks on the normal discovery path so valid repositories still produce appstore matches.

<!--
♥ Thank you for submitting a pull request. ♥

We will review it in a timely manner, but please follow the CI checks to see
any problems it might discover.

Want to make a perfect pull request?

• Keep the pull request reasonably sized. Creating more pull requests is sometimes better.
• Describe what the pull request does and what issues it does address.
• Ensure that lint and unit tests pass.
• Add tests that prove that the fix is effective or that the new feature works.
• Describe any new features or changed behavior in the documentation.
-->
