### PR TITLE
fix: bound CSV dialect sniffing input

### DIFF
--- a/translation_finder/discovery/files.py
+++ b/translation_finder/discovery/files.py
@@ -43,6 +43,7 @@ LARAVEL_BYTES_RE = re.compile(
 )
 GWT_PLURAL_RE = re.compile(r"^[^#!\s][^:=\n]*\[[a-zA-Z_]+\]\s*[:=]", re.MULTILINE)
 FORMAT_SNIFF_MAX_BYTES = 1024 * 1024
+CSV_DIALECT_SNIFF_MAX_CHARS = 1024
 CSV_SAMPLE_ROWS = 100
 SIMPLE_CSV_COLUMNS = 2
 YAML_INSPECTION_MAX_DEPTH = 128
@@ -235,7 +236,9 @@ def _read_csv_rows(finder: Finder, path: PurePath) -> list[list[str]] | None:
         return None
 
     try:
-        dialect = csv.Sniffer().sniff(text, delimiters=",;\t")
+        dialect = csv.Sniffer().sniff(
+            text[:CSV_DIALECT_SNIFF_MAX_CHARS], delimiters=",;\t"
+        )
     except csv.Error:
         dialect = csv.excel
 

--- a/translation_finder/test_discovery.py
+++ b/translation_finder/test_discovery.py
@@ -2442,6 +2442,19 @@ class CSVHelperTest(DiscoveryTestCase):
                 [["source", "target"], ["Hello", "Ahoj"]],
             )
 
+    def test_read_csv_rows_limits_dialect_sniffer_input(self) -> None:
+        content = ',"' + "a" * 5 + '",' * 2048
+        with patch.object(
+            files_module.csv.Sniffer, "sniff", return_value=csv.excel
+        ) as sniff:
+            self._read_rows(content)
+
+        sniff.assert_called_once()
+        sample = sniff.call_args.args[0]
+        self.assertEqual(sample, content[: files_module.CSV_DIALECT_SNIFF_MAX_CHARS])
+        self.assertLessEqual(len(sample), 1024)
+        self.assertEqual(sniff.call_args.kwargs, {"delimiters": ",;\t"})
+
     def test_read_csv_rows_skips_empty_rows(self) -> None:
         self.assertEqual(
             self._read_rows("source,target\n,\nHello,Ahoj\n"),


### PR DESCRIPTION
csv.Sniffer has quadratic behavior on malformed quoted input. Limit only dialect detection to 1 KiB while retaining the larger sample for row-based format refinement.

<!--
♥ Thank you for submitting a pull request. ♥

We will review it in a timely manner, but please follow the CI checks to see
any problems it might discover.

Want to make a perfect pull request?

• Keep the pull request reasonably sized. Creating more pull requests is sometimes better.
• Describe what the pull request does and what issues it does address.
• Ensure that lint and unit tests pass.
• Add tests that prove that the fix is effective or that the new feature works.
• Describe any new features or changed behavior in the documentation.
-->
